### PR TITLE
Fix misc errors

### DIFF
--- a/common/src/main/java/net/neoforged/gradle/common/extensions/obfuscation/ObfuscationExtension.java
+++ b/common/src/main/java/net/neoforged/gradle/common/extensions/obfuscation/ObfuscationExtension.java
@@ -165,7 +165,7 @@ public abstract class ObfuscationExtension implements ConfigurableDSLElement<Obf
 
             task.getObfuscatedJar().set(obfuscator.flatMap(WithOutput::getOutput));
             task.getOutputFileName().set(obfuscator.flatMap(WithOutput::getOutputFileName));
-            task.getOutput().set(project.getLayout().getBuildDirectory().file("libs/" + obfuscator.flatMap(WithOutput::getOutputFileName)));
+            task.getOutput().set(project.getLayout().getBuildDirectory().file(obfuscator.flatMap(WithOutput::getOutputFileName).map(fileName -> "libs/" + fileName)));
         });
 
         obfuscator.configure(task -> task.finalizedBy(markerGenerator));

--- a/common/src/main/java/net/neoforged/gradle/common/util/TaskDependencyUtils.java
+++ b/common/src/main/java/net/neoforged/gradle/common/util/TaskDependencyUtils.java
@@ -1,6 +1,5 @@
 package net.neoforged.gradle.common.util;
 
-import net.neoforged.gradle.common.tasks.ArtifactFromOutput;
 import net.neoforged.gradle.util.GradleInternalUtils;
 import net.neoforged.gradle.common.runtime.definition.CommonRuntimeDefinition;
 import net.neoforged.gradle.common.runtime.definition.IDelegatingRuntimeDefinition;
@@ -10,14 +9,20 @@ import net.neoforged.gradle.dsl.common.runtime.definition.Definition;
 import org.gradle.api.Buildable;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.DependencySet;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.SourceDirectorySet;
+import org.gradle.api.internal.tasks.AbstractTaskDependencyResolveContext;
+import org.gradle.api.internal.tasks.TaskDependencyContainer;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskProvider;
+import org.gradle.api.tasks.compile.JavaCompile;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-import java.util.Collection;
-import java.util.LinkedHashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public final class TaskDependencyUtils {
@@ -69,17 +74,8 @@ public final class TaskDependencyUtils {
         return extractRuntimeDefinition(project, t.get());
     }
 
-    @SuppressWarnings("unchecked")
     public static CommonRuntimeDefinition<?> extractRuntimeDefinition(@NotNull Project project, Task t) throws MultipleDefinitionsFoundException {
-        final CommonRuntimeExtension<?, ?, ? extends Definition<?>> runtimeExtension = project.getExtensions().getByType(CommonRuntimeExtension.class);
-        final Collection<? extends Definition<?>> runtimes = runtimeExtension.getRuntimes().get().values();
-        final List<? extends CommonRuntimeDefinition<?>> definitions = getDependencies(t).stream()
-                .filter(ArtifactFromOutput.class::isInstance)
-                .map(ArtifactFromOutput.class::cast)
-                .flatMap(afo -> runtimes.stream().filter(runtime -> afo.getName().startsWith(runtime.getSpecification().getName())))
-                .distinct()
-                .map(runtime -> (CommonRuntimeDefinition<?>) runtime)
-                .collect(Collectors.toList());
+        Collection<? extends CommonRuntimeDefinition<?>> definitions = findRuntimes(project, t);
 
         if (definitions.isEmpty()) {
             throw new IllegalStateException("Could not find runtime definition for task: " + t.getName());
@@ -92,8 +88,18 @@ public final class TaskDependencyUtils {
         return undelegated.get(0);
     }
 
+    private static Collection<? extends CommonRuntimeDefinition<?>> findRuntimes(Project project, Task t) {
+        FileCollection files = t.getInputs().getFiles();
+        if (files instanceof TaskDependencyContainer) {
+            RuntimeFindingTaskDependencyResolveContext context = new RuntimeFindingTaskDependencyResolveContext(project);
+            ((TaskDependencyContainer) files).visitDependencies(context);
+            return context.getRuntimes();
+        }
+        return Collections.emptySet();
+    }
+
     @SuppressWarnings("SuspiciousMethodCalls")
-    private static List<CommonRuntimeDefinition<?>> unwrapDelegation(final Project project, final List<? extends CommonRuntimeDefinition<?>> input) {
+    private static List<CommonRuntimeDefinition<?>> unwrapDelegation(final Project project, final Collection<? extends CommonRuntimeDefinition<?>> input) {
         final List<CommonRuntimeDefinition<?>> output = new LinkedList<>();
 
         GradleInternalUtils.getExtensions(project.getExtensions())
@@ -114,5 +120,57 @@ public final class TaskDependencyUtils {
                         .noneMatch(r -> r.getDelegate().equals(runtime))).collect(Collectors.toList());
         output.addAll(noneDelegated);
         return output.stream().distinct().collect(Collectors.toList());
+    }
+
+    private static class RuntimeFindingTaskDependencyResolveContext extends AbstractTaskDependencyResolveContext {
+        private final Set<Object> seen = new HashSet<>();
+        private final Set<CommonRuntimeDefinition<?>> found = new HashSet<>();
+        private final SourceSetContainer sourceSets;
+        private final Collection<? extends Definition<?>> runtimes;
+        @SuppressWarnings("unchecked")
+
+        public RuntimeFindingTaskDependencyResolveContext(Project project) {
+            this.sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
+            final CommonRuntimeExtension<?, ?, ? extends Definition<?>> runtimeExtension = project.getExtensions().getByType(CommonRuntimeExtension.class);
+            this.runtimes = runtimeExtension.getRuntimes().get().values();
+        }
+
+        @Override
+        public void add(@NotNull Object dependency) {
+            if (!this.seen.add(dependency)) {
+                return;
+            }
+            if (dependency instanceof SourceDirectorySet) {
+                sourceSets.stream()
+                        .filter(sourceSet ->
+                                sourceSet.getAllJava() == dependency ||
+                                sourceSet.getResources() == dependency ||
+                                sourceSet.getJava() == dependency ||
+                                sourceSet.getAllSource() == dependency)
+                        .map(SourceSet::getCompileClasspath)
+                        .forEach(this::add);
+            } else if (dependency instanceof JavaCompile) {
+                this.add(((JavaCompile) dependency).getClasspath());
+            } else if (dependency instanceof Configuration) {
+                DependencySet dependencies = ((Configuration) dependency).getAllDependencies();
+                runtimes.stream()
+                        .filter(runtime -> dependencies.contains(runtime.getReplacedDependency()))
+                        .map(runtime -> (CommonRuntimeDefinition<?>) runtime)
+                        .forEach(found::add);
+            } else if (dependency instanceof TaskDependencyContainer) {
+                TaskDependencyContainer container = (TaskDependencyContainer)dependency;
+                container.visitDependencies(this);
+            }
+        }
+
+        @Nullable
+        @Override
+        public Task getTask() {
+            return null;
+        }
+
+        public Collection<? extends CommonRuntimeDefinition<?>> getRuntimes() {
+            return found;
+        }
     }
 }

--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/util/CommonRuntimeUtils.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/util/CommonRuntimeUtils.groovy
@@ -40,7 +40,8 @@ final class CommonRuntimeUtils {
     }
 
     static String buildTaskName(String name, ResolvedDependency resolvedDependency) {
-        final String dependencyName = StringUtils.capitalize(resolvedDependency.getName());
+        final String dependencyClassifier = resolvedDependency.getModuleArtifacts().iterator().next().getClassifier();
+        final String dependencyName = StringUtils.capitalize(resolvedDependency.getName() + (dependencyClassifier == null ? "" : ":" + dependencyClassifier));
         final String validDependencyName = dependencyName.replaceAll("[/\\\\:<>\"?*|]", "_");
 
         final String validName = name.replaceAll("[/\\\\:<>\"?*|]", "_");

--- a/userdev/src/main/java/net/neoforged/gradle/userdev/tasks/JarJar.java
+++ b/userdev/src/main/java/net/neoforged/gradle/userdev/tasks/JarJar.java
@@ -222,7 +222,7 @@ public abstract class JarJar extends Jar {
         if (versionRange.isPresent()) {
             return versionRange.get();
         }
-        final Optional<String> attributeVersion = getProject().getExtensions().getByType(JarJarExtension.class).getRange(dependency);
+        final Optional<String> attributeVersion = getProject().getExtensions().getByType(net.neoforged.gradle.dsl.userdev.extension.JarJar.class).getRange(dependency);
 
         return attributeVersion.orElseGet(() -> Objects.requireNonNull(dependency.getVersion()));
     }
@@ -232,7 +232,7 @@ public abstract class JarJar extends Jar {
         if (version.isPresent()) {
             return version.get();
         }
-        final Optional<String> attributeVersion = getProject().getExtensions().getByType(JarJarExtension.class).getPin(dependency);
+        final Optional<String> attributeVersion = getProject().getExtensions().getByType(net.neoforged.gradle.dsl.userdev.extension.JarJar.class).getPin(dependency);
 
         return attributeVersion.orElseGet(() -> Objects.requireNonNull(dependency.getVersion()));
     }


### PR DESCRIPTION
This PR fixes the following errors:
- Duplicate task name error when using dependencies that only differ in the classifier
- No runtime definition found error for default test sourceset
- No runtime definition found error for default sources jar
- JarJar task configuration failing because of the usage of the wrong type to get the JarJar extension
- Random Provider#toString as name for jar in build/libs