### PR TITLE
Add installer logo property to installer task

### DIFF
--- a/platform/src/main/java/net/neoforged/gradle/platform/tasks/CreateLegacyInstaller.java
+++ b/platform/src/main/java/net/neoforged/gradle/platform/tasks/CreateLegacyInstaller.java
@@ -35,6 +35,10 @@ public abstract class CreateLegacyInstaller extends Zip implements WithOutput, W
         from(getLauncherJson());
         from(getInstallerJson());
         from(getUrlIcon());
+        exclude("big_logo.png");
+        from(getInstallerLogo(), spec -> {
+            spec.rename(original -> "big_logo.png");
+        });
         
         from(getUnixServerArgs(), spec -> {
             spec.rename(name -> "data/unix_args.txt");
@@ -55,6 +59,7 @@ public abstract class CreateLegacyInstaller extends Zip implements WithOutput, W
         });
         
         getUrlIcon().fileValue(getProject().getRootProject().file("src/main/resources/url.png"));
+        getInstallerLogo().fileValue(getProject().getRootProject().file("src/main/resources/neoforged_logo.png"));
         from(getData(), spec -> {
             spec.into("data");
             spec.filter(s -> {
@@ -94,6 +99,10 @@ public abstract class CreateLegacyInstaller extends Zip implements WithOutput, W
     @InputFile
     @PathSensitive(PathSensitivity.NONE)
     public abstract RegularFileProperty getUrlIcon();
+    
+    @InputFile
+    @PathSensitive(PathSensitivity.NONE)
+    public abstract RegularFileProperty getInstallerLogo();
     
     @InputFile
     @PathSensitive(PathSensitivity.NONE)


### PR DESCRIPTION
This PR adds an installer logo property to the `CreateLegacyInstaller` task, for changing the logo shown on the installer window. By default, the installer logo is taken from the root project's `src/main/resources/neoforged_logo.png` file, which is the logo file in the NeoForged repository.

Future work should be done to create our own version of the installer base with our logo and other enhancements and fixes. See [neoforged/LegacyInstaller](https://github.com/neoforged/LegacyInstaller), which is currently unmodified and unpublished.

Tested by assembling the installer in the NeoForge repository (via the `assemble` task, and looking in `projects/neoforge/build/libs`) and running it.

See https://github.com/neoforged/NeoForge/pull/210#discussion_r1377235593 for why this PR was made here in NeoGradle, and not done on the side of NeoForge (in its buildscript).