### PR TITLE
Fix "d != java.math.BigDecimal" failure resulting from BigDecimal division

### DIFF
--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/tasks/Execute.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/tasks/Execute.groovy
@@ -130,7 +130,7 @@ interface Execute extends WithWorkspace, WithOutput, WithJavaVersion, ExecuteSpe
                 java.getMainClass().set(mainClass)
                 java.setStandardOutput(log_out)
 
-                java.setMaxHeapSize(String.format("%dk", Runtime.getRuntime().maxMemory() / 1000))
+                java.setMaxHeapSize(String.format("%dm", Runtime.getRuntime().maxMemory().intdiv(1024 * 1024)))
             }).rethrowFailure().assertNormalExitValue()
         }
     }

--- a/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/tasks/RecompileSourceJar.java
+++ b/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/tasks/RecompileSourceJar.java
@@ -101,7 +101,7 @@ public abstract class RecompileSourceJar extends JavaCompile implements Runtime 
         getOptions().setFork(true);
         getOptions().setIncremental(true);
         getOptions().getIncrementalAfterFailure().set(true);
-        getOptions().getForkOptions().setMemoryMaximumSize(String.format("%dk", java.lang.Runtime.getRuntime().maxMemory() / 1000));
+        getOptions().getForkOptions().setMemoryMaximumSize(String.format("%dm", java.lang.Runtime.getRuntime().maxMemory() / (1024 * 1024)));
 
         //Leave this as an anon class, so that gradle is aware of this. Lambdas can not be used during task tree analysis.
         //noinspection Convert2Lambda


### PR DESCRIPTION
Apparently Groovy is insane and division results in BigDecimal for two integer operands.