### PR TITLE
Added a GHA Pull-Request Workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,47 @@
+name: 'Build Pull Request'
+run-name: Build for PR ${{ github.event.pull_request.number }}
+
+on:
+  pull_request:
+    types:
+      - synchronize
+      - opened
+      - ready_for_review
+      - reopened
+
+jobs:
+  build:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1000
+          fetch-tags: true
+
+      - name: Setup JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'microsoft'
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
+      - name: Build
+        run: ./gradlew --info -s -x check build
+
+      - name: Test
+        run: ./gradlew --info -s check
+
+      # Always upload test results
+      - name: Merge Test Reports
+        if: success() || failure()
+        run: npx junit-report-merger junit.xml "**/TEST-*.xml"
+
+      - uses: actions/upload-artifact@v3
+        if: success() || failure()
+        with:
+          name: test-results
+          path: junit.xml

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,0 +1,23 @@
+name: 'Test Report'
+on:
+  workflow_run:
+    workflows: ['Build Pull Request']
+    types:
+      - completed
+permissions:
+  contents: read
+  actions: read
+  checks: write
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: neoforged/action-test-reporter@v1
+        with:
+          artifact: test-results
+          name: Test Report
+          path: '**/*.xml'
+          reporter: java-junit
+        # This should not affect the result of the check created
+        # for the origin PR. This just affects this post-processing job itself.
+        continue-on-error: true


### PR DESCRIPTION
There is also a separate test-reporting workflow to allow the reporting of JUnit test results as a Github check, even if the build is running without write-permission (i.e. the PR is made from a fork).

Potential future work: Bump the memory limits for the gradle daemon or specifically the tests (?)
The free GH Action VMs have ~7GB RAM.