### PR TITLE
Fix multiple AT files not working when final file name matches

### DIFF
--- a/common/src/main/java/net/neoforged/gradle/common/util/CommonRuntimeTaskUtils.java
+++ b/common/src/main/java/net/neoforged/gradle/common/util/CommonRuntimeTaskUtils.java
@@ -32,7 +32,16 @@ public final class CommonRuntimeTaskUtils {
             
             final TaskProvider<? extends WithOutput> provider = definition.getSpecification().getProject().getTasks().register(name, ArtifactProvider.class, task -> {
                 task.getInput().set(file);
-                task.getOutput().set(new File(workspaceDirectory, "accesstransformers/" + namePreFix + "/" + file.getName()));
+                String outputFileName = file.getName();
+                if (index > 0) {
+                    int extensionDot = outputFileName.lastIndexOf('.');
+                    if (extensionDot == -1) {
+                        outputFileName += "_" + index;
+                    } else {
+                        outputFileName = outputFileName.substring(0, extensionDot) + "_" + index + outputFileName.substring(extensionDot);
+                    }
+                }
+                task.getOutput().set(new File(workspaceDirectory, "accesstransformers/" + namePreFix + "/" + outputFileName));
             });
             
             fileProducingTasks.add(provider);


### PR DESCRIPTION
Currently for cases like Mekanism where we have multiple mods separated by sourceset but different submods may need additional AT files that have to be named `accesstransformer.cfg` so that they work in prod the AT generation is broken as it overrides the copies of the AT files with the last file. For example:
```groovy
minecraft {
    accessTransformers {
        files(
                file('src/main/resources/META-INF/accesstransformer.cfg'),
                file('src/additions/resources/META-INF/accesstransformer.cfg')
        )
    }
}
```
Was only outputting a single file to `build/neoForm/neoFormJoined1.20.2-20231019.002635/accesstransformers/User/accesstransformer.cfg` which contained additions' ATs but not the base ones. This PR makes it so that it creates a second file in that folder called `accesstransformer_1.cfg` so that then when passing them along it can apply both of them. This is a similar solution as what is done for creating the task's name