### PR TITLE
Pre-create the idePostSync Task in IntelliJ

### DIFF
--- a/common/src/main/java/net/neoforged/gradle/common/extensions/IdeManagementExtension.java
+++ b/common/src/main/java/net/neoforged/gradle/common/extensions/IdeManagementExtension.java
@@ -38,6 +38,14 @@ public abstract class IdeManagementExtension {
             if (!rootProject.getPlugins().hasPlugin(EclipsePlugin.class))
                 rootProject.getPlugins().apply(EclipsePlugin.class);
         }
+
+        // Always pre-create the idePostSync task if IntelliJ is importing the project, since
+        // IntelliJ remembers to run the task post-sync even if the import fails. That will cause
+        // situations where import errors (i.e. dependency resolution errors) will be masked by
+        // the failed idePostSync task, since it was never created in that particular import.
+        if (isIdeaImport()) {
+            getOrCreateIdeImportTask();
+        }
     }
 
     /**


### PR DESCRIPTION
This fixes a usability problem where the IDE would report an error such as `Task 'idePostSync' not found in root project[...]` when reloading the Gradle project failed.

IntelliJ seemingly "remembers" from the last successful import that it should run `idePostSync` after a sync, and will do so even if the sync fails and never creates such a task.

This change always pre-creates the empty `idePostSync` task when the project is being imported by IntelliJ, even if the project import didn't get to a point where it would have been filled with live.