### PR TITLE
Fail fast when a dependency replacement handler throws an unhandled exception

### DIFF
--- a/common/src/main/java/net/neoforged/gradle/common/extensions/dependency/replacement/DependencyReplacementsExtension.java
+++ b/common/src/main/java/net/neoforged/gradle/common/extensions/dependency/replacement/DependencyReplacementsExtension.java
@@ -15,6 +15,7 @@ import net.neoforged.gradle.dsl.common.tasks.WithOutput;
 import net.neoforged.gradle.dsl.common.util.CommonRuntimeUtils;
 import net.neoforged.gradle.dsl.common.util.ModuleReference;
 import net.neoforged.gradle.util.TransformerUtils;
+import org.gradle.api.GradleException;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
@@ -143,9 +144,11 @@ public abstract class DependencyReplacementsExtension implements ConfigurableDSL
                         break;
                     }
                 } catch (Exception exception) {
-                    getProject().getLogger().info("Failed to process dependency replacement on handler: " + exception.getMessage(), exception);
+                    throw new GradleException("Uncaught exception while processing replacement of dependency " + dependency.getGroup() + ":" + dependency.getName()
+                            + " using handler " + handler + ": "  + exception.getMessage(), exception);
                 }
             }
+
             if (!dependencyReplacementInformation.contains(dependency, configuration)) {
                 dependencyReplacementInformation.put(dependency, configuration, candidate);
             }


### PR DESCRIPTION
The symptom I was trying to track down was all Minecraft classes suddenly no longer being found, but no build errors being logged during the build.
It turns out this was due to the Neoform "unpacked" directory being locked by Visual Studio Code on my system (so, unrelated to Neogradle). 

To make this way easier to debug for users of NeoGradle, I suggest making unhandled exceptions by dependency replacement handlers a fatal error via this PR.

This leads to a much nicer and easier to parse error message, instead of seemingly random compile errors:

> A problem occurred evaluating root project 'Forge'.
> Uncaught exception while processing replacement of dependency net.neoforged:neoforge using handler net.neoforged.gradle.common.extensions.dependency.replacement.DependencyReplacementHandlerImpl_Decorated@7a1ff96f: Cloud not clean up target directory: C:\AE2\Forge\build\neoForm\neoFormJoined1.20.2-20231019.002635\unpacked
> 