### PR TITLE
Implement support for dynamic runtime dependencies

### DIFF
--- a/common/src/main/java/net/neoforged/gradle/common/CommonProjectPlugin.java
+++ b/common/src/main/java/net/neoforged/gradle/common/CommonProjectPlugin.java
@@ -35,7 +35,9 @@ import org.gradle.plugins.ide.eclipse.EclipsePlugin;
 import org.gradle.plugins.ide.idea.IdeaPlugin;
 import org.jetbrains.gradle.ext.IdeaExtPlugin;
 
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 
 public class CommonProjectPlugin implements Plugin<Project> {
     
@@ -136,13 +138,20 @@ public class CommonProjectPlugin implements Plugin<Project> {
                 
                 if (run.getConfigureFromDependencies().get()) {
                     final RunImpl runImpl = (RunImpl) run;
+                    
+                    final Set<CommonRuntimeDefinition<?>> definitionSet = new HashSet<>();
+                    
                     runImpl.getModSources().get().forEach(sourceSet -> {
                         try {
                             final Optional<CommonRuntimeDefinition<?>> definition = TaskDependencyUtils.findRuntimeDefinition(project, sourceSet);
-                            definition.ifPresent(def -> def.configureRun(runImpl));
+                            definition.ifPresent(definitionSet::add);
                         } catch (MultipleDefinitionsFoundException e) {
                             throw new RuntimeException("Failed to configure run: " + run.getName() + " there are multiple runtime definitions found for the source set: " + sourceSet.getName(), e);
                         }
+                    });
+                    
+                    definitionSet.forEach(definition -> {
+                       definition.configureRun(runImpl);
                     });
                 }
             }

--- a/common/src/main/java/net/neoforged/gradle/common/runs/run/ConfigurationRunDependencyImpl.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runs/run/ConfigurationRunDependencyImpl.java
@@ -1,0 +1,31 @@
+package net.neoforged.gradle.common.runs.run;
+
+import net.neoforged.gradle.dsl.common.runs.run.RunDependency;
+import net.neoforged.gradle.dsl.common.util.ConfigurationUtils;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.ResolvedConfiguration;
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.provider.Property;
+
+import javax.inject.Inject;
+
+public abstract class ConfigurationRunDependencyImpl implements RunDependency {
+
+    @Inject
+    public ConfigurationRunDependencyImpl(Project project, Configuration dependency) {
+        getIdentity().convention(dependency.toString());
+        getDependency().from(project.provider(() -> {
+            final ResolvedConfiguration resolvedConfiguration = dependency.getResolvedConfiguration();
+            final ConfigurableFileCollection files = project.files();
+            return files.from(resolvedConfiguration.getFiles());
+        }));
+    }
+
+    @Override
+    public abstract ConfigurableFileCollection getDependency();
+
+    @Override
+    public abstract Property<String> getIdentity();
+}

--- a/common/src/main/java/net/neoforged/gradle/common/runs/run/ConfigurationRunDependencyImpl.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runs/run/ConfigurationRunDependencyImpl.java
@@ -13,6 +13,8 @@ import javax.inject.Inject;
 
 public abstract class ConfigurationRunDependencyImpl implements RunDependency {
 
+    private final Project project;
+    
     @Inject
     public ConfigurationRunDependencyImpl(Project project, Configuration dependency) {
         getIdentity().convention(dependency.toString());
@@ -21,8 +23,14 @@ public abstract class ConfigurationRunDependencyImpl implements RunDependency {
             final ConfigurableFileCollection files = project.files();
             return files.from(resolvedConfiguration.getFiles());
         }));
+        this.project = project;
     }
-
+    
+    @Override
+    public Project getProject() {
+        return project;
+    }
+    
     @Override
     public abstract ConfigurableFileCollection getDependency();
 

--- a/common/src/main/java/net/neoforged/gradle/common/runs/run/DependencyHandlerImpl.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runs/run/DependencyHandlerImpl.java
@@ -4,6 +4,7 @@ import net.neoforged.gradle.dsl.common.runs.run.DependencyHandler;
 import net.neoforged.gradle.dsl.common.runs.run.RunDependency;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 
 import javax.inject.Inject;
@@ -69,5 +70,10 @@ public abstract class DependencyHandlerImpl implements DependencyHandler {
     public RunDependency project(Map<String, ?> notation) {
         final Dependency dependency = project.getDependencies().project(notation);
         return project.getObjects().newInstance(RunDependencyImpl.class, project, dependency);
+    }
+    
+    @Override
+    public RunDependency configuration(Configuration notation) {
+        return project.getObjects().newInstance(ConfigurationRunDependencyImpl.class, project, notation);
     }
 }

--- a/common/src/main/java/net/neoforged/gradle/common/runs/run/RunDependencyImpl.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runs/run/RunDependencyImpl.java
@@ -13,6 +13,8 @@ import javax.inject.Inject;
 
 public abstract class RunDependencyImpl implements RunDependency {
 
+    private final Project project;
+    
     @Inject
     public RunDependencyImpl(Project project, Dependency dependency) {
         getIdentity().convention(dependency.toString());
@@ -22,8 +24,14 @@ public abstract class RunDependencyImpl implements RunDependency {
             final ConfigurableFileCollection files = project.files();
             return files.from(resolvedConfiguration.getFiles());
         }));
+        this.project = project;
     }
-
+    
+    @Override
+    public Project getProject() {
+        return project;
+    }
+    
     @Override
     public abstract ConfigurableFileCollection getDependency();
 

--- a/common/src/main/java/net/neoforged/gradle/common/runtime/definition/CommonRuntimeDefinition.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runtime/definition/CommonRuntimeDefinition.java
@@ -23,7 +23,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -172,7 +171,7 @@ public abstract class CommonRuntimeDefinition<S extends CommonRuntimeSpecificati
     }
     
     public void configureRun(RunImpl run) {
-        final Map<String, String> runtimeInterpolationData = buildRunInterpolationData();
+        final Map<String, String> runtimeInterpolationData = buildRunInterpolationData(run);
 
         final Map<String, String> workingInterpolationData = new HashMap<>(runtimeInterpolationData);
         workingInterpolationData.put("source_roots", RunsUtil.buildGradleModClasses(run.getModSources()).get());
@@ -191,7 +190,7 @@ public abstract class CommonRuntimeDefinition<S extends CommonRuntimeSpecificati
         }
     }
 
-    protected Map<String, String> buildRunInterpolationData() {
+    protected Map<String, String> buildRunInterpolationData(RunImpl run) {
         final Map<String, String> interpolationData = Maps.newHashMap();
 
         interpolationData.put("runtime_name", specification.getVersionedName());

--- a/common/src/main/java/net/neoforged/gradle/common/util/run/RunsUtil.java
+++ b/common/src/main/java/net/neoforged/gradle/common/util/run/RunsUtil.java
@@ -29,6 +29,14 @@ public class RunsUtil {
         throw new IllegalStateException("Tried to create utility class!");
     }
     
+    public static String createTaskName(final Run run) {
+        return createTaskName(run.getName());
+    }
+    
+    public static String createTaskName(final String prefix, final Run run) {
+        return createTaskName(prefix, run.getName());
+    }
+    
     public static Run create(final Project project, final String name) {
         final RunImpl run = project.getObjects().newInstance(RunImpl.class, project, name);
         
@@ -112,11 +120,15 @@ public class RunsUtil {
     }
     
     private static String createTaskName(final String runName) {
+        return createTaskName("run", runName);
+    }
+    
+    private static String createTaskName(final String prefix, final String runName) {
         final String conventionTaskName = runName.replaceAll("[^a-zA-Z0-9\\-_]", "");
         if (conventionTaskName.startsWith("run")) {
             return conventionTaskName;
         }
         
-        return "run" + StringCapitalizationUtils.capitalize(conventionTaskName);
+        return prefix + StringCapitalizationUtils.capitalize(conventionTaskName);
     }
 }

--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/runs/run/DependencyHandler.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/runs/run/DependencyHandler.groovy
@@ -5,6 +5,7 @@ import net.minecraftforge.gdi.BaseDSLElement
 import net.minecraftforge.gdi.annotations.ClosureEquivalent
 import net.minecraftforge.gdi.annotations.DSLProperty
 import org.gradle.api.Action
+import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.tasks.Input
@@ -84,4 +85,12 @@ interface DependencyHandler extends BaseDSLElement<DependencyHandler> {
      * @return The run dependency.
      */
     RunDependency project(Map<String, ?> notation);
+
+    /**
+     * Creates a new run dependency from the given configuration notation.
+     *
+     * @param notation The configuration to use.
+     * @return The run dependency.
+     */
+    RunDependency configuration(Configuration notation);
 }

--- a/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/definition/NeoFormRuntimeDefinition.java
+++ b/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/definition/NeoFormRuntimeDefinition.java
@@ -110,8 +110,8 @@ public class NeoFormRuntimeDefinition extends CommonRuntimeDefinition<NeoFormRun
     }
 
     @Override
-    public Map<String, String> buildRunInterpolationData() {
-        final Map<String, String> interpolationData = new HashMap<>(super.buildRunInterpolationData());
+    public Map<String, String> buildRunInterpolationData(RunImpl run) {
+        final Map<String, String> interpolationData = new HashMap<>(super.buildRunInterpolationData(run));
 
         interpolationData.put("mcp_version", neoform.getVersion());
         interpolationData.put("mcp_mappings", new File(unpackedneoformZipDirectory, "config/joined.srg").getAbsolutePath());

--- a/platform/src/main/java/net/neoforged/gradle/platform/extensions/DynamicProjectExtension.java
+++ b/platform/src/main/java/net/neoforged/gradle/platform/extensions/DynamicProjectExtension.java
@@ -363,7 +363,7 @@ public abstract class DynamicProjectExtension implements BaseDSLElement<DynamicP
                 profile.processor(project, processor -> {
                     processor.server();
                     processor.getJar().set("net.minecraftforge:installertools:1.3.0");
-                    processor.arguments("--task", "EXTRACT_FILES", "--archive", "{INSTALLER}",
+                    processor.getArguments().addAll("--task", "EXTRACT_FILES", "--archive", "{INSTALLER}",
                             
                             "--from", "data/run.sh", "--to", "{ROOT}/run.sh", "--exec", "{ROOT}/run.sh",
                             
@@ -378,42 +378,42 @@ public abstract class DynamicProjectExtension implements BaseDSLElement<DynamicP
                 profile.processor(project, processor -> {
                     processor.server();
                     processor.getJar().set("net.minecraftforge:installertools:1.3.0");
-                    processor.arguments("--task", "BUNDLER_EXTRACT", "--input", "{MINECRAFT_JAR}", "--output", "{ROOT}/libraries/", "--libraries");
+                    processor.getArguments().addAll("--task", "BUNDLER_EXTRACT", "--input", "{MINECRAFT_JAR}", "--output", "{ROOT}/libraries/", "--libraries");
                 });
                 profile.processor(project, processor -> {
                     processor.server();
                     processor.getJar().set("net.minecraftforge:installertools:1.3.0");
-                    processor.arguments("--task", "BUNDLER_EXTRACT", "--input", "{MINECRAFT_JAR}", "--output", "{MC_UNPACKED}", "--jar-only");
+                    processor.getArguments().addAll("--task", "BUNDLER_EXTRACT", "--input", "{MINECRAFT_JAR}", "--output", "{MC_UNPACKED}", "--jar-only");
                 });
                 profile.processor(project, processor -> {
                     processor.getJar().set("net.minecraftforge:installertools:1.3.0");
-                    processor.arguments("--task", "MCP_DATA", "--input", String.format("[%s]", runtimeDefinition.getJoinedNeoFormRuntimeDefinition().getSpecification().getNeoFormArtifact().toString()), "--output", "{MAPPINGS}", "--key", "mappings");
+                    processor.getArguments().addAll("--task", "MCP_DATA", "--input", String.format("[%s]", runtimeDefinition.getJoinedNeoFormRuntimeDefinition().getSpecification().getNeoFormArtifact().toString()), "--output", "{MAPPINGS}", "--key", "mappings");
                 });
                 profile.processor(project, processor -> {
                     processor.getJar().set("net.minecraftforge:installertools:1.3.0");
-                    processor.arguments("--task", "DOWNLOAD_MOJMAPS", "--version", runtimeDefinition.getSpecification().getMinecraftVersion(), "--side", "{SIDE}", "--output", "{MOJMAPS}");
+                    processor.getArguments().addAll("--task", "DOWNLOAD_MOJMAPS", "--version", runtimeDefinition.getSpecification().getMinecraftVersion(), "--side", "{SIDE}", "--output", "{MOJMAPS}");
                 });
                 profile.processor(project, processor -> {
                     processor.getJar().set("net.minecraftforge:installertools:1.3.0");
-                    processor.arguments("--task", "MERGE_MAPPING", "--left", "{MAPPINGS}", "--right", "{MOJMAPS}", "--output", "{MERGED_MAPPINGS}", "--classes", "--fields", "--methods", "--reverse-right");
+                    processor.getArguments().addAll("--task", "MERGE_MAPPING", "--left", "{MAPPINGS}", "--right", "{MOJMAPS}", "--output", "{MERGED_MAPPINGS}", "--classes", "--fields", "--methods", "--reverse-right");
                 });
                 profile.processor(project, processor -> {
                     processor.client();
                     processor.getJar().set("net.minecraftforge:jarsplitter:1.1.4");
-                    processor.arguments("--input", "{MINECRAFT_JAR}", "--slim", "{MC_SLIM}", "--extra", "{MC_EXTRA}", "--srg", "{MERGED_MAPPINGS}");
+                    processor.getArguments().addAll("--input", "{MINECRAFT_JAR}", "--slim", "{MC_SLIM}", "--extra", "{MC_EXTRA}", "--srg", "{MERGED_MAPPINGS}");
                 });
                 profile.processor(project, processor -> {
                     processor.server();
                     processor.getJar().set("net.minecraftforge:jarsplitter:1.1.4");
-                    processor.arguments("--input", "{MC_UNPACKED}", "--slim", "{MC_SLIM}", "--extra", "{MC_EXTRA}", "--srg", "{MERGED_MAPPINGS}");
+                    processor.getArguments().addAll("--input", "{MC_UNPACKED}", "--slim", "{MC_SLIM}", "--extra", "{MC_EXTRA}", "--srg", "{MERGED_MAPPINGS}");
                 });
                 profile.processor(project, processor -> {
                     processor.getJar().set(Constants.FART);
-                    processor.arguments("--input", "{MC_SLIM}", "--output", "{MC_SRG}", "--names", "{MERGED_MAPPINGS}", "--ann-fix", "--ids-fix", "--src-fix", "--record-fix");
+                    processor.getArguments().addAll("--input", "{MC_SLIM}", "--output", "{MC_SRG}", "--names", "{MERGED_MAPPINGS}", "--ann-fix", "--ids-fix", "--src-fix", "--record-fix");
                 });
                 profile.processor(project, processor -> {
                     processor.getJar().set("net.minecraftforge:binarypatcher:1.1.1");
-                    processor.arguments("--clean", "{MC_SRG}", "--output", "{PATCHED}", "--apply", "{BINPATCH}");
+                    processor.getArguments().addAll("--clean", "{MC_SRG}", "--output", "{PATCHED}", "--apply", "{BINPATCH}");
                 });
                 
                 profile.getLibraries().add(Library.fromOutput(signUniversalJar, project, "net.neoforged", "neoforge", project.getVersion().toString(), "universal"));

--- a/platform/src/main/java/net/neoforged/gradle/platform/runtime/runtime/definition/RuntimeDevRuntimeDefinition.java
+++ b/platform/src/main/java/net/neoforged/gradle/platform/runtime/runtime/definition/RuntimeDevRuntimeDefinition.java
@@ -71,8 +71,8 @@ public final class RuntimeDevRuntimeDefinition extends CommonRuntimeDefinition<R
     }
 
     @Override
-    protected Map<String, String> buildRunInterpolationData() {
-        final Map<String, String> interpolationData = joinedNeoFormRuntimeDefinition.buildRunInterpolationData();
+    protected Map<String, String> buildRunInterpolationData(RunImpl run) {
+        final Map<String, String> interpolationData = joinedNeoFormRuntimeDefinition.buildRunInterpolationData(run);
         return interpolationData;
     }
 

--- a/vanilla/src/main/java/net/neoforged/gradle/vanilla/runtime/VanillaRuntimeDefinition.java
+++ b/vanilla/src/main/java/net/neoforged/gradle/vanilla/runtime/VanillaRuntimeDefinition.java
@@ -73,7 +73,7 @@ public final class VanillaRuntimeDefinition extends CommonRuntimeDefinition<Vani
     }
 
     @Override
-    protected Map<String, String> buildRunInterpolationData() {
+    protected Map<String, String> buildRunInterpolationData(RunImpl run) {
         final Map<String, String> interpolationData = Maps.newHashMap();
 
         final String fgVersion = this.getClass().getPackage().getImplementationVersion();
@@ -100,7 +100,7 @@ public final class VanillaRuntimeDefinition extends CommonRuntimeDefinition<Vani
             run.getIsClient().set(true);
             run.getIsSingleInstance().set(false);
             
-            final Map<String, String> interpolationData = Maps.newHashMap(buildRunInterpolationData());
+            final Map<String, String> interpolationData = Maps.newHashMap(buildRunInterpolationData(run));
 
             interpolationData.put(InterpolationConstants.GAME_DIRECTORY, run.getWorkingDirectory().get().getAsFile().getAbsolutePath());
             run.overrideJvmArguments(interpolate(run.getJvmArguments(), interpolationData, "$"));


### PR DESCRIPTION
## Run specific dependency management
This implements run specific dependency management for the classpath of a run.
In the past this had to happen via a manual modification of the "minecraft_classpath" token, however tokens don't exist anymore as a component that can be configured on a run.
It was as such not possible to add none FML aware libraries to your classpath of a run.
This PR enables this feature again.


## Usage:
### Direct
```groovy
dependencies {
    implementation 'some:library:1.2.3'
}

runs {
   testRun {
      dependencies {
         runtime 'some:library:1.2.3'
      }
   }
}
```
### Configuration
```groovy
configurations {
   libraries {}
   implementation.extendsFrom libraries
}

dependencies {
    libraries 'some:library:1.2.3'
}

runs {
   testRun {
      dependencies {
         runtime configuration(project.configurations.libraries)
      }
   }
}
```
### General description
The dependency handler on a run works very similar to a projects own dependency handler, however it has only one "configuration" available to add dependencies to: "runtime". Additionally it provides a method to use when you want to turn an entire configuration into a runtime dependency.

## PR Details
### Requirements:
As in F/NG6 you still need to add the library dependency either to the compile or runtime classpath of the sourceset that you use as a mod sourceset.
Beyond that you will now need to tell each run that needs it, what dependency it should load.

### API Changes
- Add support for Configurations on a runs dependency handler.
- Added a prerun task that needs to be ran so that the minecraft classpath file can be generated for your run.

### Implementation changes:
- Previously the task to generate the relevant minecraft classpath file was configured on a per runtime basis in the userdev, this is now on a per run basis. Given that a run can only have a single userdev artifact this should not cause any issues with respect to task naming.
- The minecraft classpath file generator now also consumes the runs own dependency runtime handler results.
- The minecraft classpath file generator is now eagerly configured as it is created on a per run basis.
- The repo writing task for each userdev artifact is stored for later configurations and eagerly configured runs are added to a delayed configuration list.
