### PR TITLE
Use the full project path to compare projects in the platform plugin

### DIFF
--- a/platform/src/main/java/net/neoforged/gradle/platform/PlatformSettingsPlugin.java
+++ b/platform/src/main/java/net/neoforged/gradle/platform/PlatformSettingsPlugin.java
@@ -46,7 +46,7 @@ public class PlatformSettingsPlugin implements Plugin<Settings> {
 
             final Optional<ProjectDescriptor> match = projectManagementExtension.getDynamicProjects().
                     stream()
-                    .filter(desc -> desc.getName().equals(project.getName()))
+                    .filter(desc -> desc.getPath().equals(project.getPath()))
                     .findFirst();
 
             match.ifPresent(desc -> project.getPlugins().apply(PlatformPlugin.class));


### PR DESCRIPTION
Use the full project path to decide whether dynamic project management should apply the platform plugin.

This fixes issues when Neoforge is checked out in a `neoforge` directory, leading the root project to be considered the same as the `neoforge` subproject by the plugin.