### PR TITLE
Switch to Gradles approach for serializing System properties

### DIFF
--- a/common/src/main/java/net/neoforged/gradle/common/runs/run/RunImpl.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runs/run/RunImpl.java
@@ -173,9 +173,14 @@ public abstract class RunImpl implements ConfigurableDSLElement<Run>, Run {
     public List<String> realiseJvmArguments() {
         final List<String> args = new ArrayList<>(getJvmArguments().get());
 
-        getSystemProperties().get().forEach((key, value) -> {
-            args.add(String.format("-D%s=\"%s\"", key, value));
-        });
+        // This mirrors the logic found in Gradle itself, which also does not quote key nor value
+        for (Map.Entry<String, String> entry : getSystemProperties().get().entrySet()) {
+            if (entry.getValue() != null && !entry.getValue().isEmpty()) {
+                args.add("-D" + entry.getKey() + "=" + entry.getValue());
+            } else {
+                args.add("-D" + entry.getKey());
+            }
+        }
 
         return args;
     }


### PR DESCRIPTION
Gradle expects the user to escape quotes in system properties themselves and relies on quoting the entire JVM argument that a system property is encoded as. (so `systemProperty "a  b", "c  d"` is encoded as `-Da  b=c  d`, which is then quoted in its entirety). 

Also apply this quoting to VM arguments that are passed on to the Eclipse run configuration since the ECL library just joins VM arguments with spaces, without further quoting.