### PR TITLE
Remove the ignore list regex

### DIFF
--- a/platform/src/main/java/net/neoforged/gradle/platform/extensions/DynamicProjectExtension.java
+++ b/platform/src/main/java/net/neoforged/gradle/platform/extensions/DynamicProjectExtension.java
@@ -747,12 +747,7 @@ public abstract class DynamicProjectExtension implements BaseDSLElement<DynamicP
         tokenizedTask.token("MC_VERSION", runtimeDefinition.getSpecification().getMinecraftVersion());
         tokenizedTask.token("MCP_VERSION", runtimeDefinition.getJoinedNeoFormRuntimeDefinition().getSpecification().getNeoFormVersion());
         tokenizedTask.token("FORGE_GROUP", tokenizedTask.getProject().getGroup());
-        tokenizedTask.token("IGNORE_LIST", ignoreConfigurations.stream().flatMap(config -> config.getFiles().stream()).map(file -> {
-            if (file.getName().startsWith("events") || file.getName().startsWith("core")) {
-                return file.getName();
-            }
-            return file.getName().replaceAll("([-_]([.\\d]*\\d+)|\\.jar$)", "");
-        }).collect(Collectors.joining(",")));
+        tokenizedTask.token("IGNORE_LIST", ignoreConfigurations.stream().flatMap(config -> config.getFiles().stream()).map(File::getName).collect(Collectors.joining(",")));
         tokenizedTask.token("PLUGIN_LAYER_LIBRARIES", pluginLayerLibraries.getFiles().stream().map(File::getName).collect(Collectors.joining(",")));
         tokenizedTask.token("GAME_LAYER_LIBRARIES", gameLayerLibraries.getFiles().stream().map(File::getName).collect(Collectors.joining(",")));
         tokenizedTask.token("MODULES", "ALL-MODULE-PATH");
@@ -767,7 +762,7 @@ public abstract class DynamicProjectExtension implements BaseDSLElement<DynamicP
         return project.provider(() -> {
             StringBuilder ignoreList = new StringBuilder(1000);
             for (Configuration cfg : Arrays.asList(moduleOnlyConfiguration, gameLayerLibraryConfiguration, pluginLayerLibraryConfiguration)) {
-                ignoreList.append(cfg.getFiles().stream().map(file -> (file.getName().startsWith("events") || file.getName().startsWith("core") ? file.getName() : file.getName().replaceAll("([-_]([.\\d]*\\d+)|\\.jar$)", ""))).collect(Collectors.joining(","))).append(",");
+                ignoreList.append(cfg.getFiles().stream().map(File::getName).collect(Collectors.joining(","))).append(",");
             }
             ignoreList.append("client-extra").append(",").append(project.getName()).append("-");
             return ignoreList.toString();


### PR DESCRIPTION
The regex attempts to remove version information from the jar, so that it would go from `artifact-name-<version>.jar` to `artifact-name` in the BSL ignore list. But the full name will work as well. See https://github.com/McModLauncher/bootstraplauncher/blob/d1e91742561c9ea37c035c0fec2bd756967a1395/src/main/java/cpw/mods/bootstraplauncher/BootstrapLauncher.java#L70.

And in fact the full name is already being used by fml-core and fml-events (jar names `core-<version>.jar` and `events-<version>.jar`) because `core` is too generic of a prefix to be excluding, and same for `event`.

It was buggy when paired with versions with classifiers, and is simply not needed. No implementations of maven downloaders will rename the file. So just remove the core/events special cases and the regex altogether.