### PR TITLE
Implement a fallback when including non-NeoGradle source sets in a run

### DIFF
--- a/common/src/main/java/net/neoforged/gradle/common/runs/ide/IdeRunIntegrationManager.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runs/ide/IdeRunIntegrationManager.java
@@ -37,7 +37,7 @@ import java.io.UncheckedIOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -237,10 +237,10 @@ public class IdeRunIntegrationManager {
         
         private static Map<String, String> adaptEnvironment(
                 final RunImpl run,
-                final Function<ListProperty<SourceSet>, Provider<String>> modClassesProvider
+                final BiFunction<Project, ListProperty<SourceSet>, Provider<String>> modClassesProvider
                 ) {
             final Map<String, String> environment = new HashMap<>(run.getEnvironmentVariables().get());
-            environment.put("MOD_CLASSES", modClassesProvider.apply(run.getModSources()).get());
+            environment.put("MOD_CLASSES", modClassesProvider.apply(run.getProject(), run.getModSources()).get());
             return environment;
         }
     }

--- a/common/src/main/java/net/neoforged/gradle/common/runtime/definition/CommonRuntimeDefinition.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runtime/definition/CommonRuntimeDefinition.java
@@ -174,7 +174,7 @@ public abstract class CommonRuntimeDefinition<S extends CommonRuntimeSpecificati
         final Map<String, String> runtimeInterpolationData = buildRunInterpolationData(run);
 
         final Map<String, String> workingInterpolationData = new HashMap<>(runtimeInterpolationData);
-        workingInterpolationData.put("source_roots", RunsUtil.buildGradleModClasses(run.getModSources()).get());
+        workingInterpolationData.put("source_roots", RunsUtil.buildGradleModClasses(run.getProject(), run.getModSources()).get());
 
         if (run.getIsClient().get()) {
             getVersionJson().getPlatformJvmArgs().forEach(arg -> run.getJvmArguments().add(arg));

--- a/common/src/main/java/net/neoforged/gradle/common/util/SourceSetUtils.java
+++ b/common/src/main/java/net/neoforged/gradle/common/util/SourceSetUtils.java
@@ -1,5 +1,6 @@
 package net.neoforged.gradle.common.util;
 
+import net.neoforged.gradle.dsl.common.extensions.Minecraft;
 import net.neoforged.gradle.dsl.common.extensions.ProjectHolder;
 import net.neoforged.gradle.dsl.common.extensions.RunnableSourceSet;
 import org.gradle.api.Project;
@@ -37,12 +38,18 @@ public class SourceSetUtils {
         
         throw new IllegalStateException("Could not find project for source set " + sourceSet.getName());
     }
-    
-    public static String getModIdentifier(final SourceSet sourceSet) {
+
+    /**
+     * Gets the mod-id to use for passing this source set to FML.
+     * @param runProject If the source set isn't part of a project where the NeoGradle plugin has been applied,
+     *                   we use this project to determine the mod id instead.
+     */
+    public static String getModIdentifier(SourceSet sourceSet, Project runProject) {
         final RunnableSourceSet runnableSourceSet = sourceSet.getExtensions().findByType(RunnableSourceSet.class);
         if (runnableSourceSet != null)
             return runnableSourceSet.getModIdentifier().get();
-        
-        return getProject(sourceSet).getName();
+
+        Minecraft minecraft = runProject.getExtensions().getByType(Minecraft.class);
+        return minecraft.getModIdentifier().get();
     }
 }


### PR DESCRIPTION
Implement a fallback when including source sets that do not have NeoGradle applied so they get merged with the sources from the project in which the runs are defined.

This fixes issues with the multi-loader setups (i.e. JEIs) where a Common project is managed by sponges VanillaGradle, while the NeoForge projects are managed by NeoGradle.

In this case, the mod author just wants to have all their projects merged into a single mod at runtime:
- project(":Common").sourceSets.main [VanillaGradle]
- project(":CommonApi").sourceSets.main [VanillaGradle]
- project(":NeoForgeApi").sourceSets.main [NeoGradle]
- project(":NeoForge").sourceSets.main [NeoGradle]

With the changes in this PR, this becomes possible by specifying a mod-id on the NeoGradle and NeoGradleApi projects and  including the source-sets of Common and CommonApi as usual, since these two projects will then inherit the mod id `jei`.

```
minecraft {
	modIdentifier.set("jei")
}
```