### PR TITLE
Improve JSON Deserialization / Fix dangling file handles

### DIFF
--- a/common/src/main/java/net/neoforged/gradle/common/runtime/tasks/ListLibraries.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runtime/tasks/ListLibraries.java
@@ -1,12 +1,12 @@
 package net.neoforged.gradle.common.runtime.tasks;
 
-import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import net.neoforged.gradle.common.CommonProjectPlugin;
 import net.neoforged.gradle.common.caching.CentralCacheService;
 import net.neoforged.gradle.common.runtime.tasks.action.DownloadFileAction;
 import net.neoforged.gradle.common.util.FileCacheUtils;
+import net.neoforged.gradle.common.util.SerializationUtils;
 import net.neoforged.gradle.util.HashFunction;
 import net.neoforged.gradle.util.TransformerUtils;
 import org.gradle.api.file.DirectoryProperty;
@@ -94,12 +94,9 @@ public abstract class ListLibraries extends DefaultRuntime {
         return FileList.read(bundleFs.getPath("META-INF", "libraries.list")).entries;
     }
     
-    private Set<PathAndUrl> listDownloadJsonLibraries() throws IOException {
-        Gson gson = new Gson();
-        Reader reader = new FileReader(getDownloadedVersionJsonFile().getAsFile().get());
-        JsonObject json = gson.fromJson(reader, JsonObject.class);
-        reader.close();
-        
+    private Set<PathAndUrl> listDownloadJsonLibraries() {
+        JsonObject json = SerializationUtils.fromJson(getDownloadedVersionJsonFile().getAsFile().get(), JsonObject.class);
+
         // Gather all the libraries
         Set<PathAndUrl> artifacts = new HashSet<>();
         for (JsonElement libElement : json.getAsJsonArray("libraries")) {

--- a/common/src/main/java/net/neoforged/gradle/common/tasks/MinecraftVersionManifestFileCacheProvider.java
+++ b/common/src/main/java/net/neoforged/gradle/common/tasks/MinecraftVersionManifestFileCacheProvider.java
@@ -1,16 +1,13 @@
 package net.neoforged.gradle.common.tasks;
 
-import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import net.neoforged.gradle.common.util.SerializationUtils;
 import net.neoforged.gradle.dsl.common.util.CacheFileSelector;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.*;
 
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.Reader;
 import java.util.Objects;
 
 @CacheableTask
@@ -36,23 +33,17 @@ public abstract class MinecraftVersionManifestFileCacheProvider extends FileCach
     
     private void downloadVersionManifestToCache() {
         final String minecraftVersion = getMinecraftVersion().get();
-        final Gson gson = new Gson();
-        
-        try(final Reader reader = new FileReader(getLauncherManifest().get().getAsFile())) {
-            JsonObject json = gson.fromJson(reader, JsonObject.class);
-            
-            for (JsonElement e : json.getAsJsonArray("versions")) {
-                String v = e.getAsJsonObject().get("id").getAsString();
-                if (Objects.equals(minecraftVersion, "+") || v.equals(minecraftVersion)) {
-                    downloadJsonTo(e.getAsJsonObject().get("url").getAsString());
-                    return;
-                }
+
+        JsonObject json = SerializationUtils.fromJson(getLauncherManifest().get().getAsFile(), JsonObject.class);
+
+        for (JsonElement e : json.getAsJsonArray("versions")) {
+            String v = e.getAsJsonObject().get("id").getAsString();
+            if (Objects.equals(minecraftVersion, "+") || v.equals(minecraftVersion)) {
+                downloadJsonTo(e.getAsJsonObject().get("url").getAsString());
+                return;
             }
-            
-        } catch (IOException e) {
-            throw new RuntimeException("Could not read the launcher manifest", e);
         }
-        
+
         throw new IllegalStateException("Could not find the correct version json for version: " + minecraftVersion);
     }
 }

--- a/common/src/main/java/net/neoforged/gradle/common/util/VersionJson.java
+++ b/common/src/main/java/net/neoforged/gradle/common/util/VersionJson.java
@@ -27,6 +27,7 @@ import net.neoforged.gradle.dsl.common.util.Artifact;
 import java.io.*;
 import java.lang.reflect.Type;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.regex.Pattern;
@@ -42,19 +43,21 @@ public class VersionJson implements Serializable {
             .setPrettyPrinting().create();
 
 
-    public static VersionJson get(Path path) throws FileNotFoundException {
+    public static VersionJson get(Path path) throws IOException {
         return get(path.toFile());
     }
 
-    public static VersionJson get(@Nullable File file) throws FileNotFoundException {
+    public static VersionJson get(@Nullable File file) throws IOException {
         if (file == null) {
             throw new IllegalArgumentException("VersionJson File can not be null!");
         }
-        return get(new FileInputStream(file));
+        try (InputStream in = new FileInputStream(file)) {
+            return get(in);
+        }
     }
 
     public static VersionJson get(InputStream stream) {
-        return GSON.fromJson(new InputStreamReader(stream), VersionJson.class);
+        return GSON.fromJson(new InputStreamReader(stream, StandardCharsets.UTF_8), VersionJson.class);
     }
 
     private String id;

--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/configuration/VersionedConfiguration.java
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/configuration/VersionedConfiguration.java
@@ -27,6 +27,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 
 public class VersionedConfiguration {
 
@@ -35,7 +36,7 @@ public class VersionedConfiguration {
     public int spec = 1;
 
     public static int getSpec(InputStream stream) throws IOException {
-        return GSON.fromJson(new InputStreamReader(stream), VersionedConfiguration.class).spec;
+        return GSON.fromJson(new InputStreamReader(stream, StandardCharsets.UTF_8), VersionedConfiguration.class).spec;
     }
     public static int getSpec(byte[] data) throws IOException {
         return getSpec(new ByteArrayInputStream(data));

--- a/dsl/neoform/src/main/groovy/net/neoforged/gradle/dsl/neoform/configuration/NeoFormConfigConfigurationSpecV1.java
+++ b/dsl/neoform/src/main/groovy/net/neoforged/gradle/dsl/neoform/configuration/NeoFormConfigConfigurationSpecV1.java
@@ -32,6 +32,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -46,7 +47,7 @@ public class NeoFormConfigConfigurationSpecV1 extends VersionedConfiguration {
             .setPrettyPrinting().create();
 
     public static NeoFormConfigConfigurationSpecV1 get(InputStream stream) {
-        return GSON.fromJson(new InputStreamReader(stream), NeoFormConfigConfigurationSpecV1.class);
+        return GSON.fromJson(new InputStreamReader(stream, StandardCharsets.UTF_8), NeoFormConfigConfigurationSpecV1.class);
     }
     public static NeoFormConfigConfigurationSpecV1 get(byte[] data) {
         return get(new ByteArrayInputStream(data));

--- a/dsl/neoform/src/main/groovy/net/neoforged/gradle/dsl/neoform/configuration/NeoFormConfigConfigurationSpecV2.java
+++ b/dsl/neoform/src/main/groovy/net/neoforged/gradle/dsl/neoform/configuration/NeoFormConfigConfigurationSpecV2.java
@@ -24,6 +24,7 @@ import org.apache.commons.io.IOUtils;
 import org.gradle.api.tasks.Input;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -39,7 +40,7 @@ public class NeoFormConfigConfigurationSpecV2 extends NeoFormConfigConfiguration
         }
     }
     public static NeoFormConfigConfigurationSpecV2 get(InputStream stream) {
-        try(final InputStreamReader reader = new InputStreamReader(stream)) {
+        try (final InputStreamReader reader = new InputStreamReader(stream, StandardCharsets.UTF_8)) {
             return GSON.fromJson(reader, NeoFormConfigConfigurationSpecV2.class);
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/extensions/NeoFormRuntimeExtension.java
+++ b/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/extensions/NeoFormRuntimeExtension.java
@@ -51,7 +51,7 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
 import java.io.File;
-import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -274,7 +274,7 @@ public abstract class NeoFormRuntimeExtension extends CommonRuntimeExtension<Neo
         final VersionJson versionJson;
         try {
             versionJson = VersionJson.get(gameArtifacts.get(GameArtifact.VERSION_MANIFEST));
-        } catch (FileNotFoundException e) {
+        } catch (IOException e) {
             throw new RuntimeException(String.format("Failed to read VersionJson from the launcher metadata for the minecraft version: %s", spec.getMinecraftVersion()), e);
         }
 

--- a/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/tasks/DownloadCore.java
+++ b/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/tasks/DownloadCore.java
@@ -1,14 +1,11 @@
 package net.neoforged.gradle.neoform.runtime.tasks;
 
-import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import net.neoforged.gradle.common.util.FileDownloadingUtils;
+import net.neoforged.gradle.common.util.SerializationUtils;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.*;
-
-import java.io.FileReader;
-import java.io.Reader;
 
 @CacheableTask
 public abstract class DownloadCore extends DownloadFile {
@@ -24,10 +21,7 @@ public abstract class DownloadCore extends DownloadFile {
     @Override
     public void run() throws Exception {
         if (!getDownloadInfo().isPresent()) {
-            Gson gson = new Gson();
-            Reader reader = new FileReader(getDownloadedVersionJson().get().getAsFile());
-            JsonObject json = gson.fromJson(reader, JsonObject.class);
-            reader.close();
+            JsonObject json = SerializationUtils.fromJson(getDownloadedVersionJson().get().getAsFile(), JsonObject.class);
 
             JsonObject artifactInfo = json.getAsJsonObject("downloads").getAsJsonObject(getArtifact().get());
             String url = artifactInfo.get("url").getAsString();

--- a/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/tasks/DownloadVersionJson.java
+++ b/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/tasks/DownloadVersionJson.java
@@ -1,14 +1,11 @@
 package net.neoforged.gradle.neoform.runtime.tasks;
 
-import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import net.neoforged.gradle.common.util.FileDownloadingUtils;
+import net.neoforged.gradle.common.util.SerializationUtils;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.tasks.*;
-
-import java.io.FileReader;
-import java.io.Reader;
 
 @CacheableTask
 public abstract class DownloadVersionJson extends DownloadFile {
@@ -22,10 +19,7 @@ public abstract class DownloadVersionJson extends DownloadFile {
     @Override
     public void run() throws Exception {
         if (!getDownloadInfo().isPresent()) {
-            Gson gson = new Gson();
-            Reader reader = new FileReader(getDownloadedManifest().get().getAsFile());
-            JsonObject json = gson.fromJson(reader, JsonObject.class);
-            reader.close();
+            JsonObject json = SerializationUtils.fromJson(getDownloadedManifest().get().getAsFile(), JsonObject.class);
 
             for (JsonElement e : json.getAsJsonArray("versions")) {
                 String v = e.getAsJsonObject().get("id").getAsString();

--- a/userdev/src/main/java/net/neoforged/gradle/userdev/runtime/extension/UserDevRuntimeExtension.java
+++ b/userdev/src/main/java/net/neoforged/gradle/userdev/runtime/extension/UserDevRuntimeExtension.java
@@ -4,7 +4,6 @@ import com.google.gson.Gson;
 import net.neoforged.gradle.common.runtime.extensions.CommonRuntimeExtension;
 import net.neoforged.gradle.common.runtime.tasks.AccessTransformer;
 import net.neoforged.gradle.common.util.CommonRuntimeTaskUtils;
-import net.neoforged.gradle.common.util.VersionJson;
 import net.neoforged.gradle.common.util.constants.RunsConstants;
 import net.neoforged.gradle.common.util.run.TypesUtil;
 import net.neoforged.gradle.dsl.common.extensions.Mappings;
@@ -34,15 +33,12 @@ import org.gradle.api.file.FileTree;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskProvider;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import javax.inject.Inject;
 import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
-import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
-import java.util.function.Consumer;
 
 public abstract class UserDevRuntimeExtension extends CommonRuntimeExtension<UserDevRuntimeSpecification, UserDevRuntimeSpecification.Builder, UserDevRuntimeDefinition> {
     
@@ -72,8 +68,8 @@ public abstract class UserDevRuntimeExtension extends CommonRuntimeExtension<Use
         final File userDevConfigFile = new File(unpackedForgeDirectory, "config.json");
         final Gson userdevGson = UserdevProfile.createGson(getProject().getObjects());
         final UserdevProfile userDevConfigurationSpec;
-        try(final FileInputStream fileInputStream = new FileInputStream(userDevConfigFile)) {
-            userDevConfigurationSpec = userdevGson.fromJson(new InputStreamReader(fileInputStream), UserdevProfile.class);
+        try (final FileInputStream fileInputStream = new FileInputStream(userDevConfigFile)) {
+            userDevConfigurationSpec = userdevGson.fromJson(new InputStreamReader(fileInputStream, StandardCharsets.UTF_8), UserdevProfile.class);
         } catch (FileNotFoundException e) {
             throw new RuntimeException(e);
         } catch (IOException e) {

--- a/vanilla/src/main/java/net/neoforged/gradle/vanilla/runtime/extensions/VanillaRuntimeExtension.java
+++ b/vanilla/src/main/java/net/neoforged/gradle/vanilla/runtime/extensions/VanillaRuntimeExtension.java
@@ -29,7 +29,7 @@ import org.gradle.api.tasks.TaskProvider;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
-import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -75,7 +75,7 @@ public abstract class VanillaRuntimeExtension extends CommonRuntimeExtension<Van
         final VersionJson versionJson;
         try {
             versionJson = VersionJson.get(gameArtifacts.get(GameArtifact.VERSION_MANIFEST));
-        } catch (FileNotFoundException e) {
+        } catch (IOException e) {
             throw new RuntimeException(String.format("Failed to read VersionJson from the launcher metadata for the minecraft version: %s", spec.getMinecraftVersion()), e);
         }
 


### PR DESCRIPTION
Fix JSON serialization not closing the InputStream in some cases, as well as not setting the UTF-8 character set explicitly (and thus falling back to the default platform encoding).

This sometimes caused the version manifest file to be left open, causing subsequent updates to it to fail with access denied exceptions on Windows.