### PR TITLE
Add the ability to customize recompile settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To see the latest available version of NeoGradle, visit the [NeoForged project p
 ## Override Decompiler Settings
 
 The settings used by the decompiler when preparing Minecraft dependencies can be overridden
-using [Gradle properties](https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_configuration_properties).
+using [Gradle properties](https://docs.gradle.org/current/userguide/project_properties.html).
 This can be useful to trade slower build-times for being able to run NeoGradle on lower-end machines.
 
 | Property                                     | Description                                                                                                                |
@@ -19,5 +19,14 @@ This can be useful to trade slower build-times for being able to run NeoGradle o
 | `neogradle.subsystems.decompiler.maxMemory`  | How much heap memory is given to the decompiler. Can be specified either in gigabyte (`4g`) or megabyte (`4096m`).         |
 | `neogradle.subsystems.decompiler.maxThreads` | By default the decompiler uses all available CPU cores. This setting can be used to limit it to a given number of threads. |
 | `neogradle.subsystems.decompiler.logLevel`   | Can be used to override the [decompiler loglevel](https://vineflower.org/usage/#cmdoption-log).                            |
-| `neogradle.subsystems.decompiler.jvmArgs`    | Pass arbitrary JVM arguments to the decompiler. I.e. `-XX:+HeapDumpOnOutOfMemoryError`                                     |
 
+## Override Recompiler Settings
+
+The settings used by Neogradle for recompiling the decompiled Minecraft source code can be customized
+using [Gradle properties](https://docs.gradle.org/current/userguide/project_properties.html).
+
+| Property                                    | Description                                                                                                                          |
+|---------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
+| `neogradle.subsystems.recompiler.maxMemory` | How much heap memory is given to the decompiler. Can be specified either in gigabyte (`4g`) or megabyte (`4096m`). Defaults to `1g`. |
+| `neogradle.subsystems.recompiler.jvmArgs`   | Pass arbitrary JVM arguments to the forked Gradle process that runs the compiler. I.e. `-XX:+HeapDumpOnOutOfMemoryError`             |
+| `neogradle.subsystems.recompiler.args`      | Pass additional command line arguments to the Java compiler.                                                                         |

--- a/common/src/main/java/net/neoforged/gradle/common/extensions/subsystems/SubsystemsExtension.java
+++ b/common/src/main/java/net/neoforged/gradle/common/extensions/subsystems/SubsystemsExtension.java
@@ -5,31 +5,48 @@ import net.neoforged.gradle.dsl.common.extensions.subsystems.DecompilerLogLevel;
 import net.neoforged.gradle.dsl.common.extensions.subsystems.Subsystems;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
-import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.provider.Provider;
 
 import javax.inject.Inject;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 
 public abstract class SubsystemsExtension implements ConfigurableDSLElement<Subsystems>, Subsystems {
     private static final String PROPERTY_PREFIX = "neogradle.subsystems.";
+    private static final String DEFAULT_RECOMPILER_MAX_MEMORY = "1g";
     private final Project project;
 
     @Inject
     public SubsystemsExtension(Project project) {
         this.project = project;
 
-        ProviderFactory providers = project.getProviders();
-        getDecompiler().getMaxMemory().convention(providers.gradleProperty(PROPERTY_PREFIX + "decompiler.maxMemory"));
-        getDecompiler().getMaxThreads().convention(providers.gradleProperty(PROPERTY_PREFIX + "decompiler.maxThreads").map(Integer::parseUnsignedInt));
-        getDecompiler().getLogLevel().convention(providers.gradleProperty(PROPERTY_PREFIX + "decompiler.logLevel").map(s -> {
+        // Decompiler default settings
+        getDecompiler().getMaxMemory().convention(getStringProperty("decompiler.maxMemory"));
+        getDecompiler().getMaxThreads().convention(getStringProperty("decompiler.maxThreads").map(Integer::parseUnsignedInt));
+        getDecompiler().getLogLevel().convention(getStringProperty("decompiler.logLevel").map(s -> {
             try {
                 return DecompilerLogLevel.valueOf(s.toUpperCase(Locale.ROOT));
             } catch (Exception e) {
                 throw new GradleException("Unknown DecompilerLogLevel: " + s + ". Available options: " + Arrays.toString(DecompilerLogLevel.values()));
             }
         }));
-        getDecompiler().getJvmArgs().convention(providers.gradleProperty(PROPERTY_PREFIX + "decompiler.jvmArgs").map(s -> Arrays.asList(s.split("\\s+"))));
+        getDecompiler().getJvmArgs().convention(getSpaceSeparatedListProperty("decompiler.jvmArgs").orElse(Collections.emptyList()));
+
+        // Recompiler default settings
+        getRecompiler().getArgs().convention(getSpaceSeparatedListProperty("recompiler.args").orElse(Collections.emptyList()));
+        getRecompiler().getJvmArgs().convention(getSpaceSeparatedListProperty("recompiler.jvmArgs").orElse(Collections.emptyList()));
+        getRecompiler().getMaxMemory().convention(getStringProperty("recompiler.maxMemory").orElse(DEFAULT_RECOMPILER_MAX_MEMORY));
+    }
+
+    private Provider<String> getStringProperty(String propertyName) {
+        return this.project.getProviders().gradleProperty(PROPERTY_PREFIX + propertyName);
+    }
+
+    private Provider<List<String>> getSpaceSeparatedListProperty(String propertyName) {
+        return this.project.getProviders().gradleProperty(PROPERTY_PREFIX + propertyName)
+                .map(s -> Arrays.asList(s.split("\\s+")));
     }
 
     @Override

--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/extensions/subsystems/Recompiler.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/extensions/subsystems/Recompiler.groovy
@@ -1,0 +1,43 @@
+package net.neoforged.gradle.dsl.common.extensions.subsystems
+
+import groovy.transform.CompileStatic
+import net.minecraftforge.gdi.ConfigurableDSLElement
+import net.minecraftforge.gdi.annotations.DSLProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+
+/**
+ * Allows configuration of the java compiler NeoGradle uses to compile the decompiled and patched Minecraft
+ * source code.
+ */
+@CompileStatic
+interface Recompiler extends ConfigurableDSLElement<Recompiler> {
+
+    /**
+     * Allows the maximum memory provided to the decompiler to be overridden. Must be specified
+     * in the "123g" or "123m" form.
+     */
+    @Input
+    @Optional
+    @DSLProperty
+    Property<String> getMaxMemory();
+
+    /**
+     * Allows additional JVM arguments to be added to the JVM that is forked for running the compiler.
+     */
+    @Input
+    @Optional
+    @DSLProperty
+    ListProperty<String> getJvmArgs();
+
+    /**
+     * Allows additional arguments to be added to the compiler.
+     */
+    @Input
+    @Optional
+    @DSLProperty
+    ListProperty<String> getArgs();
+
+}

--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/extensions/subsystems/Subsystems.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/extensions/subsystems/Subsystems.groovy
@@ -18,4 +18,11 @@ interface Subsystems extends BaseDSLElement<Subsystems> {
     @DSLProperty
     Decompiler getDecompiler();
 
+    /**
+     * @return settings for the recompiler subsystem
+     */
+    @Nested
+    @DSLProperty
+    Recompiler getRecompiler();
+
 }

--- a/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/tasks/RecompileSourceJar.java
+++ b/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/tasks/RecompileSourceJar.java
@@ -101,7 +101,6 @@ public abstract class RecompileSourceJar extends JavaCompile implements Runtime 
         getOptions().setFork(true);
         getOptions().setIncremental(true);
         getOptions().getIncrementalAfterFailure().set(true);
-        getOptions().getForkOptions().setMemoryMaximumSize(String.format("%dm", java.lang.Runtime.getRuntime().maxMemory() / (1024 * 1024)));
 
         //Leave this as an anon class, so that gradle is aware of this. Lambdas can not be used during task tree analysis.
         //noinspection Convert2Lambda


### PR DESCRIPTION
This also sets the default memory used for the recompiler to `1g`.
I've ran tests, it also would run with `512m`, but seems slightly faster with `1g` (~10s).

These new options can also be used to run GC analysis on the javac process:
```
set ORG_GRADLE_PROJECT_neogradle.subsystems.recompiler.jvmArgs=-verbose:gc -Xlog:gc*,safepoint=info:file=C:\directory\gc.log:uptimemillis
```
(and then run garbagecat on it...)