### PR TITLE
Update TrainingWheels dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,9 +77,9 @@ subprojects.forEach { subProject ->
     subProject.dependencies.testImplementation "org.mockito:mockito-junit-jupiter:${project.mockito_version}"
     subProject.dependencies.testImplementation "org.mockito:mockito-core:${project.mockito_version}"
     subProject.dependencies.testImplementation "org.mockito:mockito-inline:${project.mockito_version}"
-    subProject.dependencies.testImplementation "net.neoforged:TrainingWheels-Base:${project.trainingwheels_version}"
-    subProject.dependencies.testImplementation "net.neoforged:TrainingWheels-Gradle-Base:${project.trainingwheels_version}"
-    subProject.dependencies.testImplementation "net.neoforged:TrainingWheels-Gradle-Functional:${project.trainingwheels_version}"
+    subProject.dependencies.testImplementation "net.neoforged.trainingwheels:trainingwheels-base:${project.trainingwheels_version}"
+    subProject.dependencies.testImplementation "net.neoforged.trainingwheels:trainingwheels-gradle-base:${project.trainingwheels_version}"
+    subProject.dependencies.testImplementation "net.neoforged.trainingwheels:trainingwheels-gradle-functional:${project.trainingwheels_version}"
 
     //Exclude duplicates.
     subProject.tasks.withType(Jar).configureEach { jarTask ->
@@ -136,7 +136,7 @@ subprojects.forEach { subProject ->
         evalSubProject.dependencies.functionalTestImplementation("org.spockframework:spock-core:${project.spock_version}-groovy-${project.groovy_version}") { spec ->
             spec.exclude group: 'org.codehaus.groovy'
         }
-        evalSubProject.dependencies.functionalTestImplementation "net.neoforged:TrainingWheels-Gradle-Functional:${project.trainingwheels_version}"
+        evalSubProject.dependencies.functionalTestImplementation "net.neoforged.trainingwheels:trainingwheels-gradle-functional:${project.trainingwheels_version}"
 
         //Configure the plugin metadata, so we can publish it.
         evalSubProject.gradlePlugin.plugins { NamedDomainObjectContainer<PluginDeclaration> plugins ->

--- a/gradle.properties
+++ b/gradle.properties
@@ -39,4 +39,4 @@ spock_version=2.1
 spock_groovy_version=3.0
 mockito_version=4.11.0
 jimfs_version=1.2
-trainingwheels_version=1.0.32
+trainingwheels_version=1.0.39


### PR DESCRIPTION
To fix paths exceeding 260 characters on Windows failing the functional tests.