### PR TITLE
Various Task Improvements (Patch, Strip, Recompile)

### DIFF
--- a/common/src/main/java/net/neoforged/gradle/common/tasks/ArtifactFromOutput.java
+++ b/common/src/main/java/net/neoforged/gradle/common/tasks/ArtifactFromOutput.java
@@ -5,8 +5,9 @@ import net.neoforged.gradle.dsl.common.tasks.WithOutput;
 import org.apache.commons.io.FileUtils;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.tasks.*;
+import org.gradle.work.DisableCachingByDefault;
 
-@CacheableTask
+@DisableCachingByDefault(because = "a simple file-copy is not worthwhile to cache")
 public abstract class ArtifactFromOutput extends NeoGradleBase implements WithOutput {
 
     public ArtifactFromOutput() {

--- a/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/extensions/NeoFormRuntimeExtension.java
+++ b/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/extensions/NeoFormRuntimeExtension.java
@@ -82,7 +82,12 @@ public abstract class NeoFormRuntimeExtension extends CommonRuntimeExtension<Neo
 
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     @Nullable
-    private static TaskProvider<? extends WithOutput> createBuiltIn(final NeoFormRuntimeSpecification spec, NeoFormConfigConfigurationSpecV2 neoFormConfigV2, NeoFormConfigConfigurationSpecV1.Step step, final Map<String, TaskProvider<? extends WithOutput>> tasks, final Map<GameArtifact, TaskProvider<? extends WithOutput>> gameArtifactTaskProviders, final Optional<TaskProvider<? extends WithOutput>> adaptedInput) {
+    private static TaskProvider<? extends WithOutput> createBuiltIn(final NeoFormRuntimeSpecification spec,
+                                                                    NeoFormConfigConfigurationSpecV2 neoFormConfigV2,
+                                                                    NeoFormConfigConfigurationSpecV1.Step step,
+                                                                    final Map<String, TaskProvider<? extends WithOutput>> tasks,
+                                                                    final Map<GameArtifact, TaskProvider<? extends WithOutput>> gameArtifactTaskProviders,
+                                                                    final Optional<TaskProvider<? extends WithOutput>> adaptedInput) {
         switch (step.getType()) {
             case "decompile":
                 return createDecompile(spec, step, neoFormConfigV2);
@@ -123,7 +128,15 @@ public abstract class NeoFormRuntimeExtension extends CommonRuntimeExtension<Neo
                     );
                 });
             case "patch":
-                return spec.getProject().getTasks().register(CommonRuntimeUtils.buildTaskName(spec, step.getName()), Patch.class, task -> task.getInput().fileProvider(NeoFormRuntimeUtils.getTaskInputFor(spec, tasks, step, task)));
+                return spec.getProject().getTasks().register(
+                        CommonRuntimeUtils.buildTaskName(spec, step.getName()),
+                        Patch.class,
+                        task -> {
+                            task.getInput().fileProvider(NeoFormRuntimeUtils.getTaskInputFor(spec, tasks, step, task));
+                            task.getPatchArtifact().set(spec.getNeoFormArtifact());
+                            task.getPatchDirectory().set(neoFormConfigV2.getData("patches", spec.getDistribution().getName()));
+                        }
+                );
         }
         if (neoFormConfigV2.getSpec() >= 2) {
             switch (step.getType()) {

--- a/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/tasks/StripJar.java
+++ b/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/tasks/StripJar.java
@@ -55,20 +55,21 @@ public abstract class StripJar extends DefaultRuntime {
     }
 
     private void strip(File input, File output, boolean whitelist) throws IOException {
-        JarInputStream is = new JarInputStream(new FileInputStream(input));
-        JarOutputStream os = new JarOutputStream(new FileOutputStream(output));
+        try (JarInputStream is = new JarInputStream(new FileInputStream(input));
+             FileOutputStream fout = new FileOutputStream(output);
+             JarOutputStream os = new JarOutputStream(fout)) {
 
-        // Ignore any entry that's not allowed
-        JarEntry entry;
-        while ((entry = is.getNextJarEntry()) != null) {
-            if (!isEntryValid(entry, whitelist)) continue;
-            os.putNextEntry(entry);
-            IOUtils.copyLarge(is, os);
-            os.closeEntry();
+            // Ignore any entry that's not allowed
+            JarEntry entry;
+            while ((entry = is.getNextJarEntry()) != null) {
+                if (!isEntryValid(entry, whitelist)) {
+                    continue;
+                }
+                os.putNextEntry(entry);
+                IOUtils.copyLarge(is, os);
+                os.closeEntry();
+            }
         }
-
-        os.close();
-        is.close();
     }
 
     private boolean isEntryValid(JarEntry entry, boolean whitelist) {

--- a/userdev/src/main/java/net/neoforged/gradle/userdev/runtime/extension/UserDevRuntimeExtension.java
+++ b/userdev/src/main/java/net/neoforged/gradle/userdev/runtime/extension/UserDevRuntimeExtension.java
@@ -102,7 +102,7 @@ public abstract class UserDevRuntimeExtension extends CommonRuntimeExtension<Use
             
             builder.withPreTaskAdapter("decompile", atAndSASAdapter);
 
-            builder.withPostTaskAdapter("patch", createPatchAdapter(userDevConfigurationSpec.getSourcePatchesDirectory().get(), unpackedForgeDirectory));
+            builder.withPostTaskAdapter("patch", createPatchAdapter(userDevDependency, userDevConfigurationSpec.getSourcePatchesDirectory().get()));
 
             builder.withTaskCustomizer("inject", InjectZipContent.class, task -> configureNeoforgeInjects(
                     task,
@@ -155,10 +155,13 @@ public abstract class UserDevRuntimeExtension extends CommonRuntimeExtension<Use
         };
     }
 
-    private TaskTreeAdapter createPatchAdapter(final String patchDirectory, final File unpackForgeUserDevDirectory) {
+    private TaskTreeAdapter createPatchAdapter(Dependency userDevDependency, String patchDirectory) {
         return (definition, previousTasksOutput, runtimeWorkspace, gameArtifacts, mappingVersionData, dependentTaskConfigurationHandler) -> definition.getSpecification().getProject().getTasks().register(CommonRuntimeUtils.buildTaskName(definition.getSpecification(), "patchUserDev"), Patch.class, task -> {
+            Artifact userDevArtifact = Artifact.from(userDevDependency);
+
             task.getInput().set(previousTasksOutput.flatMap(WithOutput::getOutput));
-            task.getPatchDirectory().fileProvider(definition.getSpecification().getProject().provider(() -> new File(unpackForgeUserDevDirectory, patchDirectory)));
+            task.getPatchArtifact().set(userDevArtifact);
+            task.getPatchDirectory().set(patchDirectory);
         });
     }
 


### PR DESCRIPTION
This combines various task improvements aimed at reducing task inputs and thus the work that up-to-date checks and build-cache have to do.

- Use DiffPatches ability to apply patches directly from ZIP-Files and use the NeoForm artifact as the source directly
- Minor cleanup use try-with-resources in Strip
- Don't use doLast in RecompileSources and instead move it in to the Task action
- Don't cache ArtifactFromOutput since it's just a file copy (see Gradles own  `Copy` task for similar reasoning on their part)
