### PR TITLE
Fix extended-from Configurations not ending up in the Legacy Classpath

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-all.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/userdev/src/main/java/net/neoforged/gradle/userdev/runtime/definition/UserDevRuntimeDefinition.java
+++ b/userdev/src/main/java/net/neoforged/gradle/userdev/runtime/definition/UserDevRuntimeDefinition.java
@@ -138,7 +138,9 @@ public final class UserDevRuntimeDefinition extends CommonRuntimeDefinition<User
                     task.getInputFiles().from(this.additionalUserDevDependencies);
                     task.getInputFiles().from(neoformRuntimeDefinition.getMinecraftDependenciesConfiguration());
 
-                    task.getInputFiles().from(run.getDependencies().get().getConfiguration());
+                    Configuration userDependencies = run.getDependencies().get().getConfiguration();
+                    userDependencies.getExtendsFrom().forEach(task.getInputFiles()::from);
+                    task.getInputFiles().from(userDependencies);
                 }
         );
         configureAssociatedTask(minecraftClasspathSerializer);


### PR DESCRIPTION
ClasspathSerializer for some reason doesn't seem to consider configuration inheritance. Manually add the super-configurations to the input-files instead (mirroring what is done for additional userdev dependencies)