### PR TITLE
Resolve NeoForm & NeoForge ZIP-Archives Earlier to Access Configs in Specifications

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -43,7 +43,7 @@ jobs:
         if: success() || failure()
         run: npx junit-report-merger junit.xml "**/TEST-*.xml"
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
           name: test-results

--- a/README.md
+++ b/README.md
@@ -1,64 +1,11 @@
 # NeoGradle
 
-Minecraft mod development framework used by NeoForge and FML for the Gradle build system.
+Minecraft mod development framework, used by NeoForge and FML for the Gradle build system.
 
 For a quick start, see how the [NeoForge Mod Development Kit](https://github.com/neoforged/MDK) uses NeoGradle, or see
 our official [Documentation](https://docs.neoforged.net/neogradle/docs/).
 
 To see the latest available version of NeoGradle, visit the [NeoForged project page](https://projects.neoforged.net/neoforged/neogradle).
-
-## Apply Parchment Mappings
-
-To get human-readable parameter names in decompiled Minecraft source-code, as well as Javadocs, crowed-sourced data
-from the [Parchment project](https://parchmentmc.org) can be applied to the Minecraft source-code before it is recompiled.
-
-This is currently only supported when applying the NeoGradle userdev Plugin.
-
-The most basic configuration is using the following properties in gradle.properties:
-
-```
-neogradle.subsystems.parchment.minecraftVersion=1.20.2
-neogradle.subsystems.parchment.mappingsVersion=2023.12.10
-```
-
-The subsystem also has Gradle DSL and supports more parameters explained in the following Gradle snippet.
-
-```gradle
-subsystems {
-  parchment {
-    // The Minecraft version for which the Parchment mappings were created.
-    // This does not necessarily need to match the Minecraft version your mod targets
-    // Defaults to the value of Gradle property neogradle.subsystems.parchment.minecraftVersion
-    minecraftVersion = "1.20.2"
-    
-    // The version of Parchment mappings to apply.
-    // See https://parchmentmc.org/docs/getting-started for a list.
-    // Defaults to the value of Gradle property neogradle.subsystems.parchment.mappingsVersion
-    mappingsVersion = "2023.12.10"
-    
-    // Overrides the full Maven coordinate of the Parchment artifact to use
-    // This is computed from the minecraftVersion and mappingsVersion properties by default.
-    // If you set this property explicitly, minecraftVersion and mappingsVersion will be ignored.
-    // The built-in default value can also be overriden using the Gradle property neogradle.subsystems.parchment.parchmentArtifact
-    // parchmentArtifact = "org.parchmentmc.data:parchment-$minecraftVersion:$mappingsVersion:checked@zip"
-    
-    // Overrides the full Maven coordinate of the tool used to apply the Parchment mappings
-    // See https://github.com/neoforged/JavaSourceTransformer
-    // The built-in default value can also be overriden using the Gradle property neogradle.subsystems.parchment.toolArtifact
-    // toolArtifact = "net.neoforged.jst:jst-cli-bundle:1.0.30"
-    
-    // Set this to false if you don't want the https://maven.parchmentmc.org/ repository to be added automatically when
-    // applying Parchment mappings is enabled
-    // The built-in default value can also be overriden using the Gradle property neogradle.subsystems.parchment.addRepository
-    // addRepository = true
-    
-    // Can be used to explicitly disable this subsystem. By default, it will be enabled automatically as soon
-    // as parchmentArtifact or minecraftVersion and mappingsVersion are set.
-    // The built-in default value can also be overriden using the Gradle property neogradle.subsystems.parchment.enabled
-    // enabled = true
-  }
-}
-```
 
 ## Plugins
 
@@ -104,13 +51,66 @@ dependencies {
 }
 ```
 
+## Apply Parchment Mappings
+
+To get human-readable parameter names in decompiled Minecraft source-code, as well as Javadocs, crowdsourced data
+from the [Parchment project](https://parchmentmc.org) can be applied to the Minecraft source-code before it is recompiled.
+
+This is currently only supported when applying the NeoGradle userdev Plugin.
+
+The most basic configuration is using the following properties in gradle.properties:
+
+```
+neogradle.subsystems.parchment.minecraftVersion=1.20.2
+neogradle.subsystems.parchment.mappingsVersion=2023.12.10
+```
+
+The subsystem also has a Gradle DSL and supports more parameters, explained in the following Gradle snippet:
+
+```gradle
+subsystems {
+  parchment {
+    // The Minecraft version for which the Parchment mappings were created.
+    // This does not necessarily need to match the Minecraft version your mod targets
+    // Defaults to the value of Gradle property neogradle.subsystems.parchment.minecraftVersion
+    minecraftVersion = "1.20.2"
+    
+    // The version of Parchment mappings to apply.
+    // See https://parchmentmc.org/docs/getting-started for a list.
+    // Defaults to the value of Gradle property neogradle.subsystems.parchment.mappingsVersion
+    mappingsVersion = "2023.12.10"
+    
+    // Overrides the full Maven coordinate of the Parchment artifact to use
+    // This is computed from the minecraftVersion and mappingsVersion properties by default.
+    // If you set this property explicitly, minecraftVersion and mappingsVersion will be ignored.
+    // The built-in default value can also be overriden using the Gradle property neogradle.subsystems.parchment.parchmentArtifact
+    // parchmentArtifact = "org.parchmentmc.data:parchment-$minecraftVersion:$mappingsVersion:checked@zip"
+    
+    // Overrides the full Maven coordinate of the tool used to apply the Parchment mappings
+    // See https://github.com/neoforged/JavaSourceTransformer
+    // The built-in default value can also be overriden using the Gradle property neogradle.subsystems.parchment.toolArtifact
+    // toolArtifact = "net.neoforged.jst:jst-cli-bundle:1.0.30"
+    
+    // Set this to false if you don't want the https://maven.parchmentmc.org/ repository to be added automatically when
+    // applying Parchment mappings is enabled
+    // The built-in default value can also be overriden using the Gradle property neogradle.subsystems.parchment.addRepository
+    // addRepository = true
+    
+    // Can be used to explicitly disable this subsystem. By default, it will be enabled automatically as soon
+    // as parchmentArtifact or minecraftVersion and mappingsVersion are set.
+    // The built-in default value can also be overriden using the Gradle property neogradle.subsystems.parchment.enabled
+    // enabled = true
+  }
+}
+```
+
 ## Advanced Settings
 
 ### Override Decompiler Settings
 
 The settings used by the decompiler when preparing Minecraft dependencies can be overridden
 using [Gradle properties](https://docs.gradle.org/current/userguide/project_properties.html).
-This can be useful to trade slower build-times for being able to run NeoGradle on lower-end machines.
+This can be useful to run NeoGradle on lower-end machines, at the cost of slower build times.
 
 | Property                                     | Description                                                                                                                |
 |----------------------------------------------|----------------------------------------------------------------------------------------------------------------------------|

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-NeoGradle
-===========
+# NeoGradle
 
 Minecraft mod development framework used by NeoForge and FML for the Gradle build system.
 
@@ -61,8 +60,53 @@ subsystems {
 }
 ```
 
+## Plugins
 
-## Override Decompiler Settings
+NeoGradle is separated into several different plugins that can be applied independently of each other.
+
+### Userdev Plugin
+
+This plugin is used for building mods with NeoForge. As a modder, this will in many cases be the only plugin you use.
+
+```gradle
+plugins {
+  id 'net.neoforged.gradle.userdev' version '<neogradle_version>'
+}
+
+dependencies {
+  implementation 'net.neoforged:neoforge:<neoforge_version>'
+}
+```
+
+When this plugin detects a dependency on NeoForge, it will spring into action and create the necessary NeoForm runtime tasks to build a usable Minecraft JAR-file that contains the requested NeoForge version.
+
+### NeoForm Runtime Plugin
+
+This plugin enables use of the NeoForm runtime and allows projects to depend directly on deobfuscated but otherwise
+unmodified Minecraft artifacts.
+
+This plugin is used internally by other plugins and is usually only needed for advanced use cases.
+
+```gradle
+plugins {
+  id 'net.neoforged.gradle.neoform' version '<neogradle_version>'
+}
+
+dependencies {
+  // For depending on a Minecraft JAR-file with both client- and server-classes
+  implementation "net.minecraft:neoform_joined:<neoform-version>'
+  
+  // For depending on the Minecraft client JAR-file
+  implementation "net.minecraft:neoform_client:<neoform-version>'
+  
+  // For depending on the Minecraft dedicated server JAR-file
+  implementation "net.minecraft:neoform_server:<neoform-version>'
+}
+```
+
+## Advanced Settings
+
+### Override Decompiler Settings
 
 The settings used by the decompiler when preparing Minecraft dependencies can be overridden
 using [Gradle properties](https://docs.gradle.org/current/userguide/project_properties.html).
@@ -74,7 +118,7 @@ This can be useful to trade slower build-times for being able to run NeoGradle o
 | `neogradle.subsystems.decompiler.maxThreads` | By default the decompiler uses all available CPU cores. This setting can be used to limit it to a given number of threads. |
 | `neogradle.subsystems.decompiler.logLevel`   | Can be used to override the [decompiler loglevel](https://vineflower.org/usage/#cmdoption-log).                            |
 
-## Override Recompiler Settings
+### Override Recompiler Settings
 
 The settings used by Neogradle for recompiling the decompiled Minecraft source code can be customized
 using [Gradle properties](https://docs.gradle.org/current/userguide/project_properties.html).

--- a/common/src/main/java/net/neoforged/gradle/common/extensions/repository/IvyDummyRepositoryEntry.java
+++ b/common/src/main/java/net/neoforged/gradle/common/extensions/repository/IvyDummyRepositoryEntry.java
@@ -45,7 +45,7 @@ public abstract class IvyDummyRepositoryEntry implements ConfigurableDSLElement<
     private final Collection<RepositoryReference> dependencies;
 
     /**
-     * @param project      The project thsi entry resides in.
+     * @param project      The project this entry resides in.
      * @param group        The group of the dependency.
      * @param name         The name of the dependency.
      * @param version      The version of the dependency.

--- a/common/src/main/java/net/neoforged/gradle/common/util/ToolUtilities.java
+++ b/common/src/main/java/net/neoforged/gradle/common/util/ToolUtilities.java
@@ -2,6 +2,8 @@ package net.neoforged.gradle.common.util;
 
 import net.neoforged.gradle.dsl.common.util.ConfigurationUtils;
 import org.gradle.api.Project;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.provider.Provider;
 
 import java.io.File;
@@ -17,6 +19,20 @@ public class ToolUtilities {
                 project.getConfigurations(),
                 project.getDependencies().create(tool)
         ).getFiles().iterator().next();
+    }
+
+    public static ResolvedArtifact resolveToolArtifact(final Project project, final String tool) {
+        return ConfigurationUtils.temporaryUnhandledConfiguration(
+                project.getConfigurations(),
+                project.getDependencies().create(tool)
+        ).getResolvedConfiguration().getResolvedArtifacts().iterator().next();
+    }
+
+    public static ResolvedArtifact resolveToolArtifact(final Project project, final Dependency tool) {
+        return ConfigurationUtils.temporaryUnhandledConfiguration(
+                project.getConfigurations(),
+                tool
+        ).getResolvedConfiguration().getResolvedArtifacts().iterator().next();
     }
 
     public static Provider<File> resolveTool(final Project project, final Provider<String> tool) {

--- a/dsl/neoform/src/main/groovy/net/neoforged/gradle/dsl/neoform/runtime/specification/NeoFormSpecification.groovy
+++ b/dsl/neoform/src/main/groovy/net/neoforged/gradle/dsl/neoform/runtime/specification/NeoFormSpecification.groovy
@@ -2,9 +2,7 @@ package net.neoforged.gradle.dsl.neoform.runtime.specification
 
 import groovy.transform.CompileStatic
 import net.neoforged.gradle.dsl.common.runtime.spec.Specification
-import net.neoforged.gradle.dsl.common.util.Artifact;
 import org.gradle.api.file.FileCollection
-import org.gradle.api.provider.Provider;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -14,13 +12,13 @@ import org.jetbrains.annotations.NotNull;
 interface NeoFormSpecification extends Specification {
 
     /**
-     * Defines the NeoForm artifact that is used to build the specification.
+     * The version of NeoForm that shall be used.
      * 
-     * @return The NeoForm artifact.
+     * @return The NeoForm version.
      */
     @NotNull
-    Artifact getNeoFormArtifact();
-    
+    String getNeoFormVersion();
+
     /**
      * A collection of files which need to be added to the recompile classpath,
      * for the recompile phase to succeed.
@@ -39,76 +37,21 @@ interface NeoFormSpecification extends Specification {
     interface Builder<S extends NeoFormSpecification, B extends Builder<S, B>> extends Specification.Builder<S, B> {
 
         /**
-         * Configures the specification for use with the given NeoForm Group, extracted from the given provider.
-         *
-         * @param neoFormGroup The NeoForm Group provider.
-         * @return The builder.
+         * Configures the specification to use NeoForm in the given version.
          */
         @NotNull
-        B withNeoFormGroup(@NotNull final Provider<String> neoFormGroup);
+        default B withNeoFormVersion(@NotNull final String version) {
+            withNeoFormDependency(project.getDependencies().create("net.neoforged:neoform:" + version + "@zip"));
+        }
 
         /**
-         * Configures the specification for use with the given NeoForm Group.
+         * Configures the specification for use with the given NeoForm dependency.
          *
-         * @param neoFormGroup The NeoForm Group to use.
+         * @param dependencyNotation The coordinates of the NeoForm archive in Gradle notation.
          * @return The builder.
          */
         @NotNull
-        B withNeoFormGroup(@NotNull final String neoFormGroup);
-
-        /**
-         * Configures the specification for use with the given NeoForm Name, extracted from the given provider.
-         *
-         * @param neoFormName The NeoForm Name provider.
-         * @return The builder.
-         */
-        @NotNull
-        B withNeoFormName(@NotNull final Provider<String> neoFormName);
-
-        /**
-         * Configures the specification for use with the given NeoForm Name.
-         *
-         * @param neoFormName The NeoForm Name to use.
-         * @return The builder.
-         */
-        @NotNull
-        B withNeoFormName(@NotNull final String neoFormName);
-        
-        /**
-         * Configures the specification for use with the given NeoForm version, extracted from the given provider.
-         *
-         * @param neoFormVersion The NeoForm version provider.
-         * @return The builder.
-         */
-        @NotNull
-        B withNeoFormVersion(@NotNull final Provider<String> neoFormVersion);
-
-        /**
-         * Configures the specification for use with the given NeoForm version.
-         *
-         * @param neoFormVersion The NeoForm version to use.
-         * @return The builder.
-         */
-        @NotNull
-        B withNeoFormVersion(@NotNull final String neoFormVersion);
-
-        /**
-         * Configures the specification for use with the given NeoForm Artifact, extracted from the given provider.
-         *
-         * @param neoFormArtifact The NeoForm Artifact provider.
-         * @return The builder.
-         */
-        @NotNull
-        B withNeoFormArtifact(@NotNull final Provider<Artifact> neoFormArtifact);
-
-        /**
-         * Configures the specification for use with the given NeoForm Artifact.
-         *
-         * @param neoFormArtifact The NeoForm Artifact to use.
-         * @return The builder.
-         */
-        @NotNull
-        B withNeoFormArtifact(@NotNull final Artifact neoFormArtifact);
+        B withNeoFormDependency(@NotNull final Object dependencyNotation);
 
         /**
          * Configures the specification to use the given file collection as additional recompile dependencies.

--- a/dsl/userdev/src/main/groovy/net/neoforged/gradle/dsl/userdev/configurations/UserdevProfile.groovy
+++ b/dsl/userdev/src/main/groovy/net/neoforged/gradle/dsl/userdev/configurations/UserdevProfile.groovy
@@ -18,6 +18,7 @@ import org.gradle.api.tasks.Optional
 
 import javax.inject.Inject
 import java.lang.reflect.Type
+import java.nio.charset.StandardCharsets
 import java.util.function.BiFunction
 import java.util.function.Function
 
@@ -33,11 +34,17 @@ abstract class UserdevProfile implements ConfigurableDSLElement<UserdevProfile> 
         this.factory = factory
     }
 
-    public static Gson createGson(ObjectFactory objectFactory) {
+    static Gson createGson(ObjectFactory objectFactory) {
         return new GsonBuilder().disableHtmlEscaping()
                 .registerTypeHierarchyAdapter(UserdevProfile.class, new Serializer(objectFactory))
                 .registerTypeHierarchyAdapter(ToolExecution.class, new ToolExecution.Serializer(objectFactory))
                 .create()
+    }
+
+    static UserdevProfile get(ObjectFactory objectFactory, InputStream input) {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8))) {
+            return createGson(objectFactory).fromJson(reader, UserdevProfile.class);
+        }
     }
 
     @Input

--- a/neoform/src/main/java/net/neoforged/gradle/neoform/NeoFormProjectPlugin.java
+++ b/neoform/src/main/java/net/neoforged/gradle/neoform/NeoFormProjectPlugin.java
@@ -40,14 +40,14 @@ public class NeoFormProjectPlugin implements Plugin<Project> {
         // Needed to gain access to the common systems
         project.getPluginManager().apply(CommonPlugin.class);
 
-        NeoFormRuntimeExtension runtimeExtension = project.getExtensions().create("neoFormRuntime", NeoFormRuntimeExtension.class, project);
+        project.getExtensions().create("neoFormRuntime", NeoFormRuntimeExtension.class, project);
 
         NeoFormOfficialNamingChannelConfigurator.getInstance().configure(project);
 
-        //Setup handling of the dependencies
-        NeoFormDependencyManager.getInstance().apply(project);
+        // Setup handling of the dependencies
+        NeoFormDependencyManager.apply(project);
 
-        //Add Known repos
+        // Add Known repos
         project.getRepositories().maven(e -> {
             e.setUrl(UrlConstants.NEO_FORGE_MAVEN);
             e.metadataSources(MavenArtifactRepository.MetadataSources::mavenPom);

--- a/neoform/src/main/java/net/neoforged/gradle/neoform/dependency/NeoFormDependencyManager.java
+++ b/neoform/src/main/java/net/neoforged/gradle/neoform/dependency/NeoFormDependencyManager.java
@@ -1,6 +1,7 @@
 package net.neoforged.gradle.neoform.dependency;
 
 import com.google.common.collect.Sets;
+import net.neoforged.gradle.dsl.common.extensions.dependency.replacement.Context;
 import net.neoforged.gradle.dsl.common.util.ConfigurationUtils;
 import net.neoforged.gradle.dsl.common.util.DistributionType;
 import net.neoforged.gradle.neoform.runtime.definition.NeoFormRuntimeDefinition;
@@ -13,71 +14,104 @@ import org.gradle.api.Project;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.DependencyArtifact;
 import org.gradle.api.artifacts.ExternalModuleDependency;
+import org.gradle.api.artifacts.ModuleDependency;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 
+/**
+ * This class installs a dependency replacement handler that replaces the following dependencies with the output
+ * of a NeoForm runtime.
+ * <p>
+ * <ul>
+ *     <li>net.minecraft:neoform_client</li>
+ *     <li>net.minecraft:neoform_server</li>
+ *     <li>net.minecraft:neoform_joined</li>
+ * </ul>
+ * <p>
+ * The NeoForm version that should be used is determined from the version of the dependency.
+ */
 public final class NeoFormDependencyManager {
-    private static final NeoFormDependencyManager INSTANCE = new NeoFormDependencyManager();
-
     private NeoFormDependencyManager() {
     }
 
-    public static NeoFormDependencyManager getInstance() {
-        return INSTANCE;
-    }
-
-    public void apply(final Project project) {
+    public static void apply(final Project project) {
         final DependencyReplacement dependencyReplacer = project.getExtensions().getByType(DependencyReplacement.class);
 
         dependencyReplacer.getReplacementHandlers().create("neoForm", handler -> {
-            handler.getReplacer().set(context -> {
-                if (isNotAMatchingDependency(context.getDependency())) {
-                    return Optional.empty();
-                }
-
-                if (!(context.getDependency() instanceof ExternalModuleDependency)) {
-                    return Optional.empty();
-                }
-
-                final ExternalModuleDependency externalModuleDependency = (ExternalModuleDependency) context.getDependency();
-
-                final NeoFormRuntimeDefinition runtimeDefinition = buildNeoFormRuntimeFromDependency(project, externalModuleDependency);
-                return Optional.of(
-                        new DependencyReplacementResult(
-                                project,
-                                Optional.of(ConfigurationUtils.findReplacementConfigurations(project, context.getConfiguration())),
-                                name -> CommonRuntimeUtils.buildTaskName(runtimeDefinition, name),
-                                runtimeDefinition.getSourceJarTask(),
-                                runtimeDefinition.getRawJarTask(),
-                                runtimeDefinition.getMinecraftDependenciesConfiguration(),
-                                builder -> builder.setVersion(runtimeDefinition.getSpecification().getNeoFormVersion()),
-                                builder -> builder.setVersion(runtimeDefinition.getSpecification().getNeoFormVersion()),
-                                runtimeDefinition::setReplacedDependency,
-                                runtimeDefinition::onRepoWritten,
-                                Sets::newHashSet
-                ));
-            });
+            handler.getReplacer().set(NeoFormDependencyManager::replaceDependency);
         });
     }
 
-    private boolean isNotAMatchingDependency(final Dependency dependencyToCheck) {
-        if (dependencyToCheck instanceof ExternalModuleDependency) {
-            final ExternalModuleDependency externalModuleDependency = (ExternalModuleDependency) dependencyToCheck;
-            return !"net.minecraft".equals(externalModuleDependency.getGroup()) || !isSupportedSide(dependencyToCheck) || !hasMatchingArtifact(externalModuleDependency);
+    private static Optional<DependencyReplacementResult> replaceDependency(Context context) {
+        ModuleDependency dependency = context.getDependency();
+
+        NeoFormTarget target = getNeoFormTargetFromDependency(dependency);
+        if (target == null) {
+            return Optional.empty();
         }
 
-        return true;
+        if (target.version == null) {
+            throw new IllegalStateException("Version is missing on NeoForm dependency " + dependency);
+        }
+
+        // Build the runtime used to produce the artifact
+        Project project = context.getProject();
+        NeoFormRuntimeExtension runtimeExtension = project.getExtensions().getByType(NeoFormRuntimeExtension.class);
+        NeoFormRuntimeDefinition runtime = runtimeExtension.maybeCreate(builder -> {
+            builder.withDistributionType(target.distribution).withNeoFormVersion(target.version);
+            NeoFormRuntimeUtils.configureDefaultRuntimeSpecBuilder(project, builder);
+        });
+
+        return Optional.of(
+                new DependencyReplacementResult(
+                        project,
+                        Optional.of(ConfigurationUtils.findReplacementConfigurations(project, context.getConfiguration())),
+                        name -> CommonRuntimeUtils.buildTaskName(runtime, name),
+                        runtime.getSourceJarTask(),
+                        runtime.getRawJarTask(),
+                        runtime.getMinecraftDependenciesConfiguration(),
+                        builder -> builder.setVersion(runtime.getSpecification().getNeoFormVersion()),
+                        builder -> builder.setVersion(runtime.getSpecification().getNeoFormVersion()),
+                        runtime::setReplacedDependency,
+                        runtime::onRepoWritten,
+                        Sets::newHashSet
+                ));
     }
 
-    private boolean isSupportedSide(final Dependency dependency) {
-        return dependency.getName().equalsIgnoreCase("neoform_client") ||
-                dependency.getName().equalsIgnoreCase("neoform_server") ||
-                dependency.getName().equalsIgnoreCase("neoform_joined");
+    @Nullable
+    private static NeoFormTarget getNeoFormTargetFromDependency(ModuleDependency dependency) {
+
+        if (!"net.minecraft".equals(dependency.getGroup())) {
+            return null;
+        }
+
+        DistributionType distributionType;
+        switch (dependency.getName()) {
+            case "neoform_client":
+                distributionType = DistributionType.CLIENT;
+                break;
+            case "neoform_server":
+                distributionType = DistributionType.SERVER;
+                break;
+            case "neoform_joined":
+                distributionType = DistributionType.JOINED;
+                break;
+            default:
+                return null; // This dependency is not handled by this replacer
+        }
+
+        if (!hasMatchingArtifact(dependency)) {
+            return null;
+        }
+
+        return new NeoFormTarget(dependency.getVersion(), distributionType);
     }
 
-    private boolean hasMatchingArtifact(ExternalModuleDependency externalModuleDependency) {
+    private static boolean hasMatchingArtifact(ModuleDependency externalModuleDependency) {
         if (externalModuleDependency.getArtifacts().isEmpty()){
             return true;
         }
@@ -85,7 +119,7 @@ public final class NeoFormDependencyManager {
         return hasSourcesArtifact(externalModuleDependency);
     }
 
-    private static boolean hasSourcesArtifact(ExternalModuleDependency externalModuleDependency) {
+    private static boolean hasSourcesArtifact(ModuleDependency externalModuleDependency) {
         if (externalModuleDependency.getArtifacts().size() != 1) {
             return false;
         }
@@ -94,18 +128,14 @@ public final class NeoFormDependencyManager {
         return Objects.equals(artifact.getClassifier(), "sources") && Objects.equals(artifact.getExtension(), "jar");
     }
 
+    private static final class NeoFormTarget {
+        private final String version;
+        private final DistributionType distribution;
 
-    private static NeoFormRuntimeDefinition buildNeoFormRuntimeFromDependency(Project project, ExternalModuleDependency dependency) {
-        final NeoFormRuntimeExtension runtimeExtension = project.getExtensions().getByType(NeoFormRuntimeExtension.class);
-        return runtimeExtension.maybeCreate(builder -> {
-            builder.withDistributionType(DistributionType.valueOf(dependency.getName().toLowerCase().replace("neoform_", "").toUpperCase(Locale.ROOT)));
-            if (dependency.getVersion() == null) {
-                throw new IllegalStateException("Version is not defined on NeoForm dependency");
-            }
-
-            builder.withNeoFormDependency("net.neoform:neoform:" + dependency.getVersion() + "@zip");
-            NeoFormRuntimeUtils.configureDefaultRuntimeSpecBuilder(project, builder);
-        });
+        public NeoFormTarget(String version, DistributionType distribution) {
+            this.version = version;
+            this.distribution = distribution;
+        }
     }
     
 }

--- a/neoform/src/main/java/net/neoforged/gradle/neoform/dependency/NeoFormDependencyManager.java
+++ b/neoform/src/main/java/net/neoforged/gradle/neoform/dependency/NeoFormDependencyManager.java
@@ -10,7 +10,6 @@ import net.neoforged.gradle.dsl.common.extensions.dependency.replacement.Depende
 import net.neoforged.gradle.dsl.common.extensions.dependency.replacement.DependencyReplacementResult;
 import net.neoforged.gradle.neoform.runtime.extensions.NeoFormRuntimeExtension;
 import org.gradle.api.Project;
-import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.DependencyArtifact;
 import org.gradle.api.artifacts.ExternalModuleDependency;
@@ -53,8 +52,8 @@ public final class NeoFormDependencyManager {
                                 runtimeDefinition.getSourceJarTask(),
                                 runtimeDefinition.getRawJarTask(),
                                 runtimeDefinition.getMinecraftDependenciesConfiguration(),
-                                builder -> builder.setVersion(runtimeDefinition.getSpecification().getNeoFormArtifact().getVersion()),
-                                builder -> builder.setVersion(runtimeDefinition.getSpecification().getNeoFormArtifact().getVersion()),
+                                builder -> builder.setVersion(runtimeDefinition.getSpecification().getNeoFormVersion()),
+                                builder -> builder.setVersion(runtimeDefinition.getSpecification().getNeoFormVersion()),
                                 runtimeDefinition::setReplacedDependency,
                                 runtimeDefinition::onRepoWritten,
                                 Sets::newHashSet
@@ -66,7 +65,7 @@ public final class NeoFormDependencyManager {
     private boolean isNotAMatchingDependency(final Dependency dependencyToCheck) {
         if (dependencyToCheck instanceof ExternalModuleDependency) {
             final ExternalModuleDependency externalModuleDependency = (ExternalModuleDependency) dependencyToCheck;
-            return externalModuleDependency.getGroup() == null || !externalModuleDependency.getGroup().equals("net.minecraft") || !isSupportedSide(dependencyToCheck) || !hasMatchingArtifact(externalModuleDependency);
+            return !"net.minecraft".equals(externalModuleDependency.getGroup()) || !isSupportedSide(dependencyToCheck) || !hasMatchingArtifact(externalModuleDependency);
         }
 
         return true;
@@ -104,7 +103,7 @@ public final class NeoFormDependencyManager {
                 throw new IllegalStateException("Version is not defined on NeoForm dependency");
             }
 
-            builder.withNeoFormVersion(dependency.getVersion());
+            builder.withNeoFormDependency("net.neoform:neoform:" + dependency.getVersion() + "@zip");
             NeoFormRuntimeUtils.configureDefaultRuntimeSpecBuilder(project, builder);
         });
     }

--- a/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/extensions/NeoFormRuntimeExtension.java
+++ b/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/extensions/NeoFormRuntimeExtension.java
@@ -25,7 +25,6 @@ import net.neoforged.gradle.dsl.common.tasks.ArtifactProvider;
 import net.neoforged.gradle.dsl.common.tasks.WithOutput;
 import net.neoforged.gradle.dsl.common.tasks.specifications.OutputSpecification;
 import net.neoforged.gradle.dsl.common.util.CommonRuntimeUtils;
-import net.neoforged.gradle.dsl.common.util.ConfigurationUtils;
 import net.neoforged.gradle.dsl.common.util.DistributionType;
 import net.neoforged.gradle.dsl.common.util.GameArtifact;
 import net.neoforged.gradle.dsl.common.util.NamingConstants;
@@ -44,8 +43,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.artifacts.Dependency;
-import org.gradle.api.artifacts.ResolvedConfiguration;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.file.RegularFile;
@@ -136,7 +133,7 @@ public abstract class NeoFormRuntimeExtension extends CommonRuntimeExtension<Neo
                         Patch.class,
                         task -> {
                             task.getInput().fileProvider(NeoFormRuntimeUtils.getTaskInputFor(spec, tasks, step, task));
-                            task.getPatchArtifact().set(spec.getNeoFormArtifact());
+                            task.getPatchArchive().set(spec.getNeoFormArchive());
                             task.getPatchDirectory().set(neoFormConfigV2.getData("patches", spec.getDistribution().getName()));
                         }
                 );
@@ -258,10 +255,7 @@ public abstract class NeoFormRuntimeExtension extends CommonRuntimeExtension<Neo
         final Minecraft minecraftExtension = spec.getProject().getExtensions().getByType(Minecraft.class);
         final Mappings mappingsExtension = minecraftExtension.getMappings();
         final MinecraftArtifactCache artifactCacheExtension = spec.getProject().getExtensions().getByType(MinecraftArtifactCache.class);
-        final Dependency neoFormConfigDependency = spec.getNeoFormArtifact().toDependency(spec.getProject());
-        final Configuration neoFormDownloadConfiguration = ConfigurationUtils.temporaryConfiguration(spec.getProject(), neoFormConfigDependency);
-        final ResolvedConfiguration resolvedConfiguration = neoFormDownloadConfiguration.getResolvedConfiguration();
-        final File neoFormZipFile = resolvedConfiguration.getFiles().iterator().next();
+        final File neoFormZipFile = spec.getNeoFormArchive();
 
         final File minecraftCache = artifactCacheExtension.getCacheDirectory().get().getAsFile();
 
@@ -358,7 +352,7 @@ public abstract class NeoFormRuntimeExtension extends CommonRuntimeExtension<Neo
 
         final List<NeoFormConfigConfigurationSpecV1.Step> steps = neoFormConfig.getSteps(spec.getDistribution().getName());
         if (steps.isEmpty()) {
-            throw new IllegalArgumentException("Unknown side: " + spec.getDistribution() + " For Config: " + definition.getSpecification().getNeoFormArtifact());
+            throw new IllegalArgumentException("Unknown side: " + spec.getDistribution() + " For Config: " + definition.getSpecification().getNeoFormArchive());
         }
 
         final LinkedHashMap<String, TaskProvider<? extends WithOutput>> taskOutputs = definition.getTasks();

--- a/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/specification/NeoFormRuntimeSpecification.java
+++ b/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/specification/NeoFormRuntimeSpecification.java
@@ -16,6 +16,7 @@ import org.gradle.api.Task;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.provider.Provider;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
@@ -26,13 +27,13 @@ import java.io.IOException;
  */
 public class NeoFormRuntimeSpecification extends CommonRuntimeSpecification implements NeoFormSpecification {
     private final File neoFormArchive;
-    private final NeoFormConfigConfigurationSpecV2 spec;
+    private final NeoFormConfigConfigurationSpecV2 config;
     private final FileCollection additionalRecompileDependencies;
 
     private NeoFormRuntimeSpecification(Project project,
                                           String version,
                                           File neoFormArchive,
-                                          NeoFormConfigConfigurationSpecV2 spec,
+                                          NeoFormConfigConfigurationSpecV2 config,
                                           DistributionType side,
                                           Multimap<String, TaskTreeAdapter> preTaskTypeAdapters,
                                           Multimap<String, TaskTreeAdapter> postTypeAdapters,
@@ -40,12 +41,16 @@ public class NeoFormRuntimeSpecification extends CommonRuntimeSpecification impl
                                           FileCollection additionalRecompileDependencies) {
         super(project, "neoForm", version, side, preTaskTypeAdapters, postTypeAdapters, taskCustomizers, NeoFormRuntimeExtension.class);
         this.neoFormArchive = neoFormArchive;
-        this.spec = spec;
+        this.config = config;
         this.additionalRecompileDependencies = additionalRecompileDependencies;
     }
 
+    public NeoFormConfigConfigurationSpecV2 getConfig() {
+        return config;
+    }
+
     public String getMinecraftVersion() {
-        return spec.getVersion();
+        return config.getVersion();
     }
     
     public String getNeoFormVersion() {
@@ -127,9 +132,9 @@ public class NeoFormRuntimeSpecification extends CommonRuntimeSpecification impl
             String effectiveVersion = artifact.getModuleVersion().getId().getVersion();
 
             // Read the NF config from the archive
-            NeoFormConfigConfigurationSpecV2 spec;
+            NeoFormConfigConfigurationSpecV2 config;
             try {
-                spec = FileUtils.processFileFromZip(archive, "config.json", NeoFormConfigConfigurationSpecV2::get);
+                config = FileUtils.processFileFromZip(archive, "config.json", NeoFormConfigConfigurationSpecV2::get);
             } catch (IOException e) {
                 throw new GradleException("Failed to read NeoForm config file from version " + effectiveVersion);
             }
@@ -138,7 +143,7 @@ public class NeoFormRuntimeSpecification extends CommonRuntimeSpecification impl
                     project,
                     effectiveVersion,
                     archive,
-                    spec,
+                    config,
                     distributionType.get(),
                     preTaskAdapters,
                     postTaskAdapters,

--- a/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/tasks/Patch.java
+++ b/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/tasks/Patch.java
@@ -6,8 +6,6 @@ import codechicken.diffpatch.util.LoggingOutputStream;
 import codechicken.diffpatch.util.PatchMode;
 import codechicken.diffpatch.util.archiver.ArchiveFormat;
 import net.neoforged.gradle.common.runtime.tasks.DefaultRuntime;
-import net.neoforged.gradle.dsl.common.util.Artifact;
-import net.neoforged.gradle.dsl.common.util.ConfigurationUtils;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.api.provider.Property;
@@ -31,14 +29,12 @@ public abstract class Patch extends DefaultRuntime {
         final File input = getInput().get().getAsFile();
         final File output = ensureFileWorkspaceReady(getOutput());
         final File rejects = getRejectsFile().get().getAsFile();
-
-        // Resolve the input artifact
-        File inputArtifact = ConfigurationUtils.getArtifactProvider(getProject(), getPatchArtifact().map(Artifact::getDescriptor)).get();
+        final File patchArchive = getPatchArchive().get().getAsFile();
 
         PatchOperation.Builder builder = PatchOperation.builder()
                 .logTo(new LoggingOutputStream(getLogger(), LogLevel.LIFECYCLE))
                 .basePath(input.toPath())
-                .patchesPath(inputArtifact.toPath(), ArchiveFormat.ZIP)
+                .patchesPath(patchArchive.toPath(), ArchiveFormat.ZIP)
                 .patchesPrefix(getPatchDirectory().get())
                 .outputPath(output.toPath())
                 .level(getIsVerbose().get() ? codechicken.diffpatch.util.LogLevel.ALL : codechicken.diffpatch.util.LogLevel.WARN)
@@ -66,8 +62,9 @@ public abstract class Patch extends DefaultRuntime {
     @PathSensitive(PathSensitivity.NONE)
     public abstract RegularFileProperty getInput();
 
-    @Input
-    public abstract Property<Artifact> getPatchArtifact();
+    @InputFile
+    @PathSensitive(PathSensitivity.NONE)
+    public abstract RegularFileProperty getPatchArchive();
 
     @Input
     public abstract Property<String> getPatchDirectory();

--- a/platform/src/main/java/net/neoforged/gradle/platform/runtime/runtime/extension/RuntimeDevRuntimeExtension.java
+++ b/platform/src/main/java/net/neoforged/gradle/platform/runtime/runtime/extension/RuntimeDevRuntimeExtension.java
@@ -5,12 +5,8 @@ import net.neoforged.gradle.common.runtime.extensions.CommonRuntimeExtension;
 import net.neoforged.gradle.dsl.common.extensions.Mappings;
 import net.neoforged.gradle.dsl.common.extensions.Minecraft;
 import net.neoforged.gradle.dsl.common.tasks.ArtifactProvider;
-import net.neoforged.gradle.dsl.common.util.Artifact;
 import net.neoforged.gradle.dsl.common.util.CommonRuntimeUtils;
-import net.neoforged.gradle.dsl.common.util.DistributionType;
 import net.neoforged.gradle.neoform.runtime.definition.NeoFormRuntimeDefinition;
-import net.neoforged.gradle.neoform.runtime.extensions.NeoFormRuntimeExtension;
-import net.neoforged.gradle.neoform.util.NeoFormRuntimeUtils;
 import net.neoforged.gradle.platform.runtime.runtime.definition.RuntimeDevRuntimeDefinition;
 import net.neoforged.gradle.platform.runtime.runtime.specification.RuntimeDevRuntimeSpecification;
 import net.neoforged.gradle.platform.runtime.runtime.tasks.ApplyPatches;
@@ -20,8 +16,6 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.inject.Inject;
 import java.io.File;
-import java.util.Collections;
-import java.util.HashMap;
 
 public abstract class RuntimeDevRuntimeExtension extends CommonRuntimeExtension<RuntimeDevRuntimeSpecification, RuntimeDevRuntimeSpecification.Builder, RuntimeDevRuntimeDefinition> {
     
@@ -32,22 +26,12 @@ public abstract class RuntimeDevRuntimeExtension extends CommonRuntimeExtension<
     
     @Override
     protected @NotNull RuntimeDevRuntimeDefinition doCreate(RuntimeDevRuntimeSpecification spec) {
-        final NeoFormRuntimeExtension neoFormRuntimeExtension = getProject().getExtensions().getByType(NeoFormRuntimeExtension.class);
-        
-        final Artifact neoFormArtifact = spec.getNeoFormArtifact();
-        
         final File workingDirectory = spec.getProject().getLayout().getBuildDirectory().dir(String.format("platform/%s", spec.getIdentifier())).get().getAsFile();
-        
-        final NeoFormRuntimeDefinition joinedNeoFormRuntimeDefinition = neoFormRuntimeExtension.maybeCreate(builder -> {
-            builder.withNeoFormArtifact(neoFormArtifact)
-                    .withDistributionType(DistributionType.JOINED)
-                    .withAdditionalDependencies(spec.getAdditionalDependencies());
-            
-            NeoFormRuntimeUtils.configureDefaultRuntimeSpecBuilder(spec.getProject(), builder);
-        });
-        
+
+        NeoFormRuntimeDefinition neoformRuntime = spec.getNeoFormRuntime();
+
         final TaskProvider<ApplyPatches> patchApply = spec.getProject().getTasks().register(CommonRuntimeUtils.buildTaskName(spec, "applyPatches"), ApplyPatches.class, task -> {
-            task.getBase().set(joinedNeoFormRuntimeDefinition.getSourceJarTask().flatMap(ArtifactProvider::getOutput));
+            task.getBase().set(neoformRuntime.getSourceJarTask().flatMap(ArtifactProvider::getOutput));
             task.getPatches().set(spec.getPatchesDirectory());
             task.getRejects().set(spec.getRejectsDirectory());
             task.getPatchMode().set(spec.isUpdating() ? PatchMode.FUZZY : PatchMode.ACCESS);
@@ -62,7 +46,7 @@ public abstract class RuntimeDevRuntimeExtension extends CommonRuntimeExtension<
         
         return new RuntimeDevRuntimeDefinition(
                 spec,
-                joinedNeoFormRuntimeDefinition,
+                neoformRuntime,
                 sourcesProvider
         );
     }

--- a/userdev/src/main/java/net/neoforged/gradle/userdev/runtime/specification/UserDevRuntimeSpecification.java
+++ b/userdev/src/main/java/net/neoforged/gradle/userdev/runtime/specification/UserDevRuntimeSpecification.java
@@ -4,7 +4,6 @@ import com.google.common.collect.Multimap;
 import net.neoforged.gradle.common.runtime.specification.CommonRuntimeSpecification;
 import net.neoforged.gradle.common.util.ToolUtilities;
 import net.neoforged.gradle.dsl.common.runtime.tasks.tree.TaskCustomizer;
-import net.neoforged.gradle.dsl.common.util.ConfigurationUtils;
 import net.neoforged.gradle.dsl.common.runtime.tasks.tree.TaskTreeAdapter;
 import net.neoforged.gradle.dsl.common.util.Artifact;
 import net.neoforged.gradle.dsl.common.util.DistributionType;
@@ -16,7 +15,6 @@ import net.neoforged.gradle.util.FileUtils;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.provider.Provider;
@@ -221,15 +219,6 @@ public final class UserDevRuntimeSpecification extends CommonRuntimeSpecificatio
                     effectiveVersion.getName(),
                     effectiveVersion.getVersion()
             );
-        }
-
-        private static Artifact resolveUserDevVersion(final Project project, final Artifact current) {
-            final Configuration resolveConfig = ConfigurationUtils.temporaryConfiguration(project, current.toDependency(project));
-            return resolveConfig.getResolvedConfiguration()
-                    .getResolvedArtifacts().stream()
-                    .filter(current.asArtifactMatcher())
-                    .findFirst()
-                    .map(Artifact::from).orElse(current);
         }
     }
 }

--- a/userdev/src/main/java/net/neoforged/gradle/userdev/runtime/specification/UserDevRuntimeSpecification.java
+++ b/userdev/src/main/java/net/neoforged/gradle/userdev/runtime/specification/UserDevRuntimeSpecification.java
@@ -2,21 +2,29 @@ package net.neoforged.gradle.userdev.runtime.specification;
 
 import com.google.common.collect.Multimap;
 import net.neoforged.gradle.common.runtime.specification.CommonRuntimeSpecification;
+import net.neoforged.gradle.common.util.ToolUtilities;
 import net.neoforged.gradle.dsl.common.runtime.tasks.tree.TaskCustomizer;
 import net.neoforged.gradle.dsl.common.util.ConfigurationUtils;
 import net.neoforged.gradle.dsl.common.runtime.tasks.tree.TaskTreeAdapter;
 import net.neoforged.gradle.dsl.common.util.Artifact;
 import net.neoforged.gradle.dsl.common.util.DistributionType;
+import net.neoforged.gradle.dsl.userdev.configurations.UserdevProfile;
 import net.neoforged.gradle.dsl.userdev.extension.UserDev;
 import net.neoforged.gradle.dsl.userdev.runtime.specification.UserDevSpecification;
 import net.neoforged.gradle.userdev.runtime.extension.UserDevRuntimeExtension;
+import net.neoforged.gradle.util.FileUtils;
+import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.provider.Provider;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.Objects;
 
 /**
@@ -24,14 +32,18 @@ import java.util.Objects;
  */
 public final class UserDevRuntimeSpecification extends CommonRuntimeSpecification implements UserDevSpecification {
 
+    private final File userDevArchive;
     private final String forgeGroup;
     private final String forgeName;
     private final String forgeVersion;
+    private final UserdevProfile profile;
     @Nullable
     private String minecraftVersion = null;
 
     public UserDevRuntimeSpecification(Project project,
                                        String version,
+                                       File userDevArchive,
+                                       UserdevProfile profile,
                                        DistributionType distribution,
                                        Multimap<String, TaskTreeAdapter> preTaskTypeAdapters,
                                        Multimap<String, TaskTreeAdapter> postTypeAdapters,
@@ -40,6 +52,8 @@ public final class UserDevRuntimeSpecification extends CommonRuntimeSpecificatio
                                        String forgeName,
                                        String forgeVersion) {
         super(project, "neoForge", version, distribution, preTaskTypeAdapters, postTypeAdapters, taskCustomizers, UserDevRuntimeExtension.class);
+        this.userDevArchive = userDevArchive;
+        this.profile = profile;
         this.forgeGroup = forgeGroup;
         this.forgeName = forgeName;
         this.forgeVersion = forgeVersion;
@@ -50,12 +64,20 @@ public final class UserDevRuntimeSpecification extends CommonRuntimeSpecificatio
         return forgeVersion;
     }
 
+    public File getUserDevArchive() {
+        return userDevArchive;
+    }
+
     public String getForgeGroup() {
         return forgeGroup;
     }
 
     public String getForgeName() {
         return forgeName;
+    }
+
+    public UserdevProfile getProfile() {
+        return profile;
     }
 
     @NotNull
@@ -172,27 +194,36 @@ public final class UserDevRuntimeSpecification extends CommonRuntimeSpecificatio
             final String name = forgeNameProvider.get();
             final String version = forgeVersionProvider.get();
 
-            final Artifact universalArtifact = new Artifact(group, name, version, "userdev", "jar");
-            final Artifact resolvedArtifact = resolveUserDevVersion(project, universalArtifact);
+            final Artifact artifact = new Artifact(group, name, version, "userdev", "jar");
+            ResolvedArtifact userdevArchiveArtifact = ToolUtilities.resolveToolArtifact(project, artifact.getDescriptor());
+
+            File userdevArchive = userdevArchiveArtifact.getFile();
+            ModuleVersionIdentifier effectiveVersion = userdevArchiveArtifact.getModuleVersion().getId();
+
+            // Read the userdev profile from the archive
+            UserdevProfile profile;
+            try {
+                profile = FileUtils.processFileFromZip(userdevArchive, "config.json", in -> UserdevProfile.get(project.getObjects(), in));
+            } catch (IOException e) {
+                throw new GradleException("Failed to read userdev config file for version " + effectiveVersion, e);
+            }
 
             return new UserDevRuntimeSpecification(
                     project,
-                    resolvedArtifact.getVersion(),
+                    effectiveVersion.getVersion(),
+                    userdevArchive,
+                    profile,
                     distributionType.get(),
                     preTaskAdapters,
                     postTaskAdapters,
                     taskCustomizers,
-                    resolvedArtifact.getGroup(),
-                    resolvedArtifact.getName(),
-                    resolvedArtifact.getVersion()
+                    effectiveVersion.getGroup(),
+                    effectiveVersion.getName(),
+                    effectiveVersion.getVersion()
             );
         }
 
         private static Artifact resolveUserDevVersion(final Project project, final Artifact current) {
-            if (!Objects.equals(current.getVersion(), "+")) {
-                return current;
-            }
-
             final Configuration resolveConfig = ConfigurationUtils.temporaryConfiguration(project, current.toDependency(project));
             return resolveConfig.getResolvedConfiguration()
                     .getResolvedArtifacts().stream()

--- a/vanilla/src/main/java/net/neoforged/gradle/vanilla/dependency/VanillaDependencyManager.java
+++ b/vanilla/src/main/java/net/neoforged/gradle/vanilla/dependency/VanillaDependencyManager.java
@@ -69,7 +69,7 @@ public final class VanillaDependencyManager {
     private boolean isNotAMatchingDependency(final Dependency dependencyToCheck) {
         if (dependencyToCheck instanceof ExternalModuleDependency) {
             final ExternalModuleDependency externalModuleDependency = (ExternalModuleDependency) dependencyToCheck;
-            return externalModuleDependency.getGroup() == null || !externalModuleDependency.getGroup().equals("net.minecraft") || !isSupportedSide(dependencyToCheck) || !hasMatchingArtifact(externalModuleDependency);
+            return !"net.minecraft".equals(externalModuleDependency.getGroup()) || !isSupportedSide(dependencyToCheck) || !hasMatchingArtifact(externalModuleDependency);
         }
 
         return true;
@@ -94,7 +94,7 @@ public final class VanillaDependencyManager {
         }
 
         final DependencyArtifact artifact = externalModuleDependency.getArtifacts().iterator().next();
-        return artifact.getClassifier().equals("sources") && artifact.getExtension().equals("jar");
+        return "sources".equals(artifact.getClassifier()) && "jar".equals(artifact.getExtension());
     }
 
 


### PR DESCRIPTION
The archives are already resolved during the Gradle configuration phase (out of necessity, since the config contained within is needed to build the task graph). Doing this in the Specification build allows us to load the config earlier and simplify the architecture a bit. I did check that subsequent runs just use the archives from the local Gradle artifact cache directly - same as the NG plugin jars and other Maven dependencies.

As a side-effect, this allows us to return `Specification#getMinecraftVersion` directly from the NeoForm configuration file, instead of attempting to parse it from the version string.

What needs extra attention is how the NeoForm version is handled when building userdev- and installer-profiles in NeoForgeDev. My intent is to build the NF runtime earlier, which resolves the effective version of NF. Then I use that resolved version in the profiles. This should result in a version range of `+` still leading to the local environment and the profiles using the exact same specific NF version.
To that end, I refactored how RuntimeDevRuntime is built by having it require a pre-built NeoFormRutime, instead of duplicating all configuration parameters of the NeoFormRuntime in the RuntimeDevRuntime.

Supersedes #93 too, since I fixed the grammar in here too.