### PR TITLE
Fix applyParchment Task Inputs

### DIFF
--- a/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/extensions/NeoFormRuntimeExtension.java
+++ b/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/extensions/NeoFormRuntimeExtension.java
@@ -491,6 +491,8 @@ public abstract class NeoFormRuntimeExtension extends CommonRuntimeExtension<Neo
 
         TaskProvider<? extends Runtime> applyParchmentTask = project.getTasks().register(CommonRuntimeUtils.buildTaskName(spec, "applyParchment"), Execute.class, task -> {
             task.getInputs().file(mappingFile);
+            task.getInputs().file(recompileInput);
+            task.getInputs().file(listLibrariesOutput);
             task.getExecutingJar().fileProvider(toolExecutable);
             task.getProgramArguments().add(listLibrariesOutput.map(f -> "--libraries-list=" + f.getAsFile().getAbsolutePath()));
             task.getProgramArguments().add("--enable-parchment");


### PR DESCRIPTION
Add recompile-input as task dependency to apply parchment to fix it reusing old outputs when updating NeoForge

This should fix #90 