### PR TITLE
Don't automatically configure runs when using a `Provider<RunType>`

### DIFF
--- a/common/src/main/java/net/neoforged/gradle/common/runs/run/RunImpl.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runs/run/RunImpl.java
@@ -141,6 +141,7 @@ public abstract class RunImpl implements ConfigurableDSLElement<Run>, Run {
 
     @Override
     public void configure(@NotNull Provider<RunType> typeProvider) {
+        getConfigureFromTypeWithName().set(false); // Don't re-configure
         this.runTypes.add(typeProvider);
     }
 


### PR DESCRIPTION
This adds the missing `getConfigureFromTypeWithName().set(false)` when configuring runs with a `Provider<RunType>` to make it consistent with the other two `configure(runType)` overrides.