### PR TITLE
[NG6] Fix fg.deobf trying source downloads on every project refresh

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'eclipse'
     id 'maven-publish'
     id 'org.cadixdev.licenser' version '0.6.1'
-    id 'net.minecraftforge.gradleutils' version '[2.0.13,)'
+    id 'net.minecraftforge.gradleutils' version '[2.3,2.4)'
     id 'com.github.ben-manes.versions' version '0.46.0'
 }
 
@@ -12,8 +12,8 @@ version = gradleutils.getTagOffsetBranchVersion('FG_6.0')
 logger.lifecycle('Version: ' + version)
 
 changelog {
-    fromTag '6.0'
-    disableAutomaticPublicationRegistration()
+    from '6.0'
+    publishAll = false
 }
 sourceSets {
     common


### PR DESCRIPTION
The current `fg.deobf` logic around sources uses manual Maven downloading logic. The problem is that this is quite slow, especially if the sources don't actually exist. This concern was raised [when the code was originally added](https://github.com/MinecraftForge/ForgeGradle/pull/746#discussion_r578238592), but was unfortunately never addressed.

This PR is a simple workaround for the problem that caches download failure and does not attempt the download again. This shouldn't break any builds, as sources are only used for development QoL in an IDE, not for compilation.

Ideally, we would get rid of the Maven downloading hack entirely, but I'm not familiar enough with Gradle to suggest an alternative approach.

I tested this with https://github.com/embeddedt/OpenComputers/tree/dev-MC1.16, and it brings the time taken to refresh the project in IntelliJ from 40 seconds down to 6 seconds.