### PR TITLE
Add sync tasks for eclipse resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ repo
 .classpath
 .project
 bin
+/.vscode/
 
 # intellij
 out

--- a/common/src/main/java/net/neoforged/gradle/common/runs/ide/IdeRunIntegrationManager.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runs/ide/IdeRunIntegrationManager.java
@@ -230,6 +230,9 @@ public class IdeRunIntegrationManager {
                         task.from(defaultProcessResources.get().getDestinationDir());
                         Path outputDir = eclipse.getClasspath().getDefaultOutputDir().toPath();
                         if (outputDir.endsWith("default")) {
+                            // sometimes it has default value from org.gradle.plugins.ide.eclipse.internal.EclipsePluginConstants#DEFAULT_PROJECT_OUTPUT_PATH
+                            // which has /default on end that is not present in the final outputDir in eclipse/buildship
+                            // (output of getDefaultOutputDir() should be just project/bin/)
                             outputDir = outputDir.getParent();
                         }
                         task.into(outputDir.resolve(sourceSet.getName()));

--- a/common/src/main/java/net/neoforged/gradle/common/runs/ide/IdeRunIntegrationManager.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runs/ide/IdeRunIntegrationManager.java
@@ -40,6 +40,7 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -136,7 +137,7 @@ public class IdeRunIntegrationManager {
                     
                     final RunImpl runImpl = (RunImpl) run;
                     final TaskProvider<?> ideBeforeRunTask = createIdeBeforeRunTask(project, name, run, runImpl);
-                    addEclipseCopyResourcesTasks(eclipse, run);
+                    ideBeforeRunTask.configure(task -> addEclipseCopyResourcesTasks(eclipse, run, t -> task.dependsOn(t)));
                     
                     try {
                         final GradleLaunchConfig idePreRunTask = GradleLaunchConfig.builder(eclipse.getProject().getName())
@@ -214,7 +215,7 @@ public class IdeRunIntegrationManager {
             return ideBeforeRunTask;
         }
         
-        private void addEclipseCopyResourcesTasks(EclipseModel eclipse, Run run) {
+        private void addEclipseCopyResourcesTasks(EclipseModel eclipse, Run run, Consumer<TaskProvider<?>> tasksConsumer) {
             for (SourceSet sourceSet : run.getModSources().get()) {
                 final Project sourceSetProject = SourceSetUtils.getProject(sourceSet);
 
@@ -241,7 +242,7 @@ public class IdeRunIntegrationManager {
                     });
                 }
 
-                eclipse.autoBuildTasks(eclipseResourcesTask);
+                tasksConsumer.accept(eclipseResourcesTask);
             }
         }
 


### PR DESCRIPTION
This adds small copy task (which depends on processResources) from build/resources/* to bin/*
Tested using vscode (using my vscode PR)
Not tested using eclipse

_(disclaimer: I'm not confident with using delayed evaluation in gradle, but it works)_

EDIT: aims to resolve https://github.com/neoforged/MDK/issues/34, resolve https://github.com/neoforged/NeoGradle/issues/70