### PR TITLE
Do not change standard out/error log levels

### DIFF
--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/tasks/NeoGradleBase.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/tasks/NeoGradleBase.groovy
@@ -19,8 +19,5 @@ abstract class NeoGradleBase extends DefaultTask implements WithWorkspace {
 
     NeoGradleBase() {
         setGroup("NeoGradle");
-
-        getLogging().captureStandardOutput(LogLevel.DEBUG);
-        getLogging().captureStandardError(LogLevel.ERROR);
     }
 }

--- a/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/tasks/RecompileSourceJar.java
+++ b/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/tasks/RecompileSourceJar.java
@@ -72,8 +72,6 @@ public abstract class RecompileSourceJar extends JavaCompile implements Runtime 
 
             return toolChain.launcherFor(spec -> spec.getLanguageVersion().set(getJavaVersion()));
         }));
-        getLogging().captureStandardOutput(LogLevel.DEBUG);
-        getLogging().captureStandardError(LogLevel.ERROR);
 
         setDescription("Recompiles an already existing decompiled java jar.");
         setSource(getProject().zipTree(getInputJar()).matching(filter -> filter.include("**/*.java")));


### PR DESCRIPTION
`getLogging()` is not thread-safe in parallel builds (https://github.com/gradle/gradle/issues/27897), which can cause standard output to be permanently redirected to `DEBUG` log levels. This is especially unhelp when trying to run Minecraft itself, as you get no output, and so have to tail the log files instead!

Removing these lines fixes this issue, and doesn't appear to have any impact on what information is actually logged during normal usage.