### PR TITLE
Match `NEOFORGE_SPEC` env var to manifest's `Specification-Version`

### DIFF
--- a/platform/src/main/java/net/neoforged/gradle/platform/extensions/DynamicProjectExtension.java
+++ b/platform/src/main/java/net/neoforged/gradle/platform/extensions/DynamicProjectExtension.java
@@ -701,7 +701,7 @@ public abstract class DynamicProjectExtension implements BaseDSLElement<DynamicP
         runType.getJvmArguments().addAll("--add-exports", "java.base/sun.security.util=cpw.mods.securejarhandler");
         runType.getJvmArguments().addAll("--add-exports", "jdk.naming.dns/com.sun.jndi.dns=java.naming");
 
-        runType.getEnvironmentVariables().put("NEOFORGE_SPEC", project.getVersion().toString());
+        runType.getEnvironmentVariables().put("NEOFORGE_SPEC", project.getVersion().toString().substring(0, project.getVersion().toString().lastIndexOf(".")));
 
         runType.getClasspath().from(runtimeClasspath);
 


### PR DESCRIPTION
This PR changes the value for `NEOFORGE_SPEC` from the whole project version, to the first part of the project version before the last `.` (for example, `20.4.32-something` would become `20.4`), matching the current value in the JAR manifest for `Specification-Version`.

This fixes a discrepancy in `NeoForgeVersion.neoForgeSpec` between NeoDev (where the environment variable is used due to the lack of a JAR manifest) and both userdev and production (where the manifest value is used).

This matter was discussed in the [`#maintenance-talk` channel](https://canary.discord.com/channels/313125603924639766/1154167065519861831/1202545935587082241) on the Discord server, where the reason for the original intended discrepancy was to avoid potential bugs caused by connecting differing NeoDev branches/instances to other branches/instances (NeoDev, userdev, or production). It was decided that such a check is unneeded as it is an artificial limit on NeoDev developers, who are expected to be aware of what versions/branches/instances they are using when testing.