### PR TITLE
Allow NG7 plugins to be used as siblings

### DIFF
--- a/common/src/main/java/net/neoforged/gradle/common/CommonProjectPlugin.java
+++ b/common/src/main/java/net/neoforged/gradle/common/CommonProjectPlugin.java
@@ -53,14 +53,15 @@ public class CommonProjectPlugin implements Plugin<Project> {
 
         project.getPluginManager().apply(JavaPlugin.class);
 
+        //Register the services
+        CentralCacheService.register(project, ASSETS_SERVICE);
+        CentralCacheService.register(project, LIBRARIES_SERVICE);
+
         // Apply both the idea and eclipse IDE plugins
         project.getPluginManager().apply(IdeaPlugin.class);
+        project.getRootProject().getPluginManager().apply(IdeaExtPlugin.class);
         project.getPluginManager().apply(IdeaExtPlugin.class);
         project.getPluginManager().apply(EclipsePlugin.class);
-        
-        //Register the assets service
-        CentralCacheService.register(project, ASSETS_SERVICE, FileCacheUtils.getAssetsCacheDirectory(project));
-        CentralCacheService.register(project, LIBRARIES_SERVICE, FileCacheUtils.getLibrariesCacheDirectory(project));
         
         project.getExtensions().create("allRuntimes", RuntimesExtension.class);
         project.getExtensions().create(IdeManagementExtension.class, "ideManager", IdeManagementExtension.class, project);

--- a/common/src/main/java/net/neoforged/gradle/common/caching/CentralCacheService.java
+++ b/common/src/main/java/net/neoforged/gradle/common/caching/CentralCacheService.java
@@ -17,7 +17,7 @@ import org.gradle.api.tasks.OutputDirectory;
  */
 public abstract class CentralCacheService implements BuildService<BuildServiceParameters.None> {
     
-    public static void register(Project project, String name, Provider<Directory> cacheDirectory) {
+    public static void register(Project project, String name) {
         project.getGradle().getSharedServices().registerIfAbsent(
                 name,
                 CentralCacheService.class,

--- a/common/src/main/java/net/neoforged/gradle/common/runs/ide/IdeRunIntegrationManager.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runs/ide/IdeRunIntegrationManager.java
@@ -70,7 +70,7 @@ public class IdeRunIntegrationManager {
         final IdeaModel ideaModel = rootProject.getExtensions().getByType(IdeaModel.class);
         final IdeaProject ideaProject = ideaModel.getProject();
         final ExtensionAware extensionAware = (ExtensionAware) ideaProject;
-        if (extensionAware.getExtensions().findByType(IdeaRunsExtension.class) == null) {
+        if (extensionAware.getExtensions().findByType(IdeaRunsExtension.class) == null && extensionAware.getExtensions().findByName("runs") == null) {
             extensionAware.getExtensions().create("runs", IdeaRunsExtension.class, project);
         }
     }

--- a/vanilla/src/main/java/net/neoforged/gradle/vanilla/runtime/extensions/VanillaRuntimeExtension.java
+++ b/vanilla/src/main/java/net/neoforged/gradle/vanilla/runtime/extensions/VanillaRuntimeExtension.java
@@ -220,7 +220,7 @@ public abstract class VanillaRuntimeExtension extends CommonRuntimeExtension<Van
     private StepData buildSteps() {
         final IStep rawJarStep = new CleanManifestStep();
 
-        final IStep sourcesStep = new DecompileStep();
+        final IStep sourcesStep = new ParchmentStep();
 
         final List<IStep> steps = ImmutableList.<IStep>builder()
                 .add(new CollectLibraryInformationStep())
@@ -228,8 +228,8 @@ public abstract class VanillaRuntimeExtension extends CommonRuntimeExtension<Van
                 .add(new RenameStep())
                 .add(new ApplyAccessTransformerStep())
                 .add(rawJarStep)
+                .add(new DecompileStep())
                 .add(sourcesStep)
-                .add(new ParchmentStep())
                 .build();
 
         return new StepData(steps, rawJarStep, sourcesStep);

--- a/vanilla/src/main/java/net/neoforged/gradle/vanilla/runtime/extensions/VanillaRuntimeExtension.java
+++ b/vanilla/src/main/java/net/neoforged/gradle/vanilla/runtime/extensions/VanillaRuntimeExtension.java
@@ -229,6 +229,7 @@ public abstract class VanillaRuntimeExtension extends CommonRuntimeExtension<Van
                 .add(new ApplyAccessTransformerStep())
                 .add(rawJarStep)
                 .add(sourcesStep)
+                .add(new ParchmentStep())
                 .build();
 
         return new StepData(steps, rawJarStep, sourcesStep);

--- a/vanilla/src/main/java/net/neoforged/gradle/vanilla/runtime/steps/ParchmentStep.java
+++ b/vanilla/src/main/java/net/neoforged/gradle/vanilla/runtime/steps/ParchmentStep.java
@@ -1,0 +1,77 @@
+package net.neoforged.gradle.vanilla.runtime.steps;
+
+import com.google.common.collect.Maps;
+import net.neoforged.gradle.common.runtime.tasks.Execute;
+import net.neoforged.gradle.common.runtime.tasks.NoopRuntime;
+import net.neoforged.gradle.common.util.ToolUtilities;
+import net.neoforged.gradle.dsl.common.extensions.subsystems.Parchment;
+import net.neoforged.gradle.dsl.common.extensions.subsystems.Subsystems;
+import net.neoforged.gradle.dsl.common.runtime.tasks.Runtime;
+import net.neoforged.gradle.dsl.common.tasks.WithOutput;
+import net.neoforged.gradle.dsl.common.util.CommonRuntimeUtils;
+import net.neoforged.gradle.dsl.common.util.GameArtifact;
+import net.neoforged.gradle.vanilla.runtime.VanillaRuntimeDefinition;
+import net.neoforged.gradle.vanilla.runtime.spec.VanillaRuntimeSpecification;
+import org.gradle.api.Project;
+import org.gradle.api.file.RegularFile;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.TaskProvider;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import static net.neoforged.gradle.common.runtime.extensions.CommonRuntimeExtension.configureCommonRuntimeTaskParameters;
+
+public class ParchmentStep implements IStep {
+    @Override
+    public TaskProvider<? extends Runtime> buildTask(VanillaRuntimeDefinition definition, TaskProvider<? extends WithOutput> inputProvidingTask, @NotNull File minecraftCache, @NotNull File workingDirectory, @NotNull Map<String, TaskProvider<? extends WithOutput>> pipelineTasks, @NotNull Map<GameArtifact, TaskProvider<? extends WithOutput>> gameArtifactTasks, @NotNull Consumer<TaskProvider<? extends Runtime>> additionalTaskConfigurator) {
+
+        final TaskProvider<? extends WithOutput> collectLibraryInformationTask = pipelineTasks.get(CommonRuntimeUtils.buildTaskName(definition, "libraries"));
+
+        return maybeApplyParchment(
+                definition.getSpecification(),
+                inputProvidingTask,
+                workingDirectory,
+                collectLibraryInformationTask.flatMap(WithOutput::getOutput)
+        );
+    }
+
+    private static TaskProvider<? extends Runtime> maybeApplyParchment(VanillaRuntimeSpecification spec,
+                                                                       TaskProvider<? extends WithOutput> inputProvidingTask,
+                                                                       File vanillaDirectory,
+                                                                       Provider<RegularFile> listLibrariesOutput) {
+        Project project = spec.getProject();
+        Parchment parchment = project.getExtensions().getByType(Subsystems.class).getParchment();
+        if (!parchment.getEnabled().get()) {
+            return project.getTasks().register(CommonRuntimeUtils.buildTaskName(spec, "applyParchmentNoop"), NoopRuntime.class, task -> {
+                task.getInput().set(inputProvidingTask.flatMap(WithOutput::getOutput));
+            });
+        }
+
+        // Provide the mappings via artifact
+        Provider<File> mappingFile = ToolUtilities.resolveTool(project, parchment.getParchmentArtifact());
+        Provider<File> toolExecutable = ToolUtilities.resolveTool(project, parchment.getToolArtifact());
+
+        return project.getTasks().register(CommonRuntimeUtils.buildTaskName(spec, "applyParchment"), Execute.class, task -> {
+            task.getInputs().file(mappingFile);
+            task.getInputs().file(inputProvidingTask.flatMap(WithOutput::getOutput));
+            task.getInputs().file(listLibrariesOutput);
+            task.getExecutingJar().fileProvider(toolExecutable);
+            task.getProgramArguments().add(listLibrariesOutput.map(f -> "--libraries-list=" + f.getAsFile().getAbsolutePath()));
+            task.getProgramArguments().add("--enable-parchment");
+            task.getProgramArguments().add(mappingFile.map(f -> "--parchment-mappings=" + f.getAbsolutePath()));
+            task.getProgramArguments().add("--in-format=archive");
+            task.getProgramArguments().add("--out-format=archive");
+            task.getProgramArguments().add(inputProvidingTask.flatMap(WithOutput::getOutput).map(f -> f.getAsFile().getAbsolutePath()));
+            task.getProgramArguments().add("{output}");
+            configureCommonRuntimeTaskParameters(task, Maps.newHashMap(), "applyParchment", spec, vanillaDirectory);
+        });
+    }
+
+    @Override
+    public String getName() {
+        return "parchment";
+    }
+}


### PR DESCRIPTION
This introduces patches to the common core of NG7 to allow it to be used in sibling projects.

For example this allows the use of userdev and vanilla side by side, depending on each other where needed.

Also fixes an oversight with the Parchment implementation and allows it to be used in Vanilla.