### PR TITLE
Fix creation of eclipse process resources task

### DIFF
--- a/common/src/main/java/net/neoforged/gradle/common/runs/ide/IdeRunIntegrationManager.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runs/ide/IdeRunIntegrationManager.java
@@ -137,7 +137,8 @@ public class IdeRunIntegrationManager {
                     
                     final RunImpl runImpl = (RunImpl) run;
                     final TaskProvider<?> ideBeforeRunTask = createIdeBeforeRunTask(project, name, run, runImpl);
-                    ideBeforeRunTask.configure(task -> addEclipseCopyResourcesTasks(eclipse, run, t -> task.dependsOn(t)));
+                    final List<TaskProvider<?>> copyProcessResourcesTasks = createEclipseCopyResourcesTasks(eclipse, run);
+                    ideBeforeRunTask.configure(task -> copyProcessResourcesTasks.forEach(t -> task.dependsOn(t)));
                     
                     try {
                         final GradleLaunchConfig idePreRunTask = GradleLaunchConfig.builder(eclipse.getProject().getName())
@@ -214,8 +215,9 @@ public class IdeRunIntegrationManager {
             
             return ideBeforeRunTask;
         }
-        
-        private void addEclipseCopyResourcesTasks(EclipseModel eclipse, Run run, Consumer<TaskProvider<?>> tasksConsumer) {
+
+        private List<TaskProvider<?>> createEclipseCopyResourcesTasks(EclipseModel eclipse, Run run) {
+            final List<TaskProvider<?>> copyProcessResources = new ArrayList<>();
             for (SourceSet sourceSet : run.getModSources().get()) {
                 final Project sourceSetProject = SourceSetUtils.getProject(sourceSet);
 
@@ -242,8 +244,9 @@ public class IdeRunIntegrationManager {
                     });
                 }
 
-                tasksConsumer.accept(eclipseResourcesTask);
+                copyProcessResources.add(eclipseResourcesTask);
             }
+            return copyProcessResources;
         }
 
         private static void writeLaunchToFile(Project project, String fileName, LaunchConfig config) {

--- a/common/src/main/java/net/neoforged/gradle/common/runs/ide/IdeRunIntegrationManager.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runs/ide/IdeRunIntegrationManager.java
@@ -37,6 +37,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
Move tasks registration from task.configure into project.afterEvaluate (mimics code for ideBeforeRunTask)
Should solve [an issue reported on discord](https://discord.com/channels/313125603924639766/1185197721477468160/1204774082021957642)
Tested using vscode that this doesn't break the behaviour of eclipse copy tasks