### PR TITLE
Fix change in behavior of NeoFormRuntimeSpecification#getNeoFormVersion

### DIFF
--- a/dsl/neoform/src/main/groovy/net/neoforged/gradle/dsl/neoform/runtime/specification/NeoFormSpecification.groovy
+++ b/dsl/neoform/src/main/groovy/net/neoforged/gradle/dsl/neoform/runtime/specification/NeoFormSpecification.groovy
@@ -12,7 +12,8 @@ import org.jetbrains.annotations.NotNull;
 interface NeoFormSpecification extends Specification {
 
     /**
-     * The version of NeoForm that shall be used.
+     * The version of NeoForm that shall be used. Does not include the minecraft version as a prefix, unlike
+     * {@link Specification#getVersion()}.
      * 
      * @return The NeoForm version.
      */

--- a/neoform/src/main/java/net/neoforged/gradle/neoform/dependency/NeoFormDependencyManager.java
+++ b/neoform/src/main/java/net/neoforged/gradle/neoform/dependency/NeoFormDependencyManager.java
@@ -74,8 +74,8 @@ public final class NeoFormDependencyManager {
                         runtime.getSourceJarTask(),
                         runtime.getRawJarTask(),
                         runtime.getMinecraftDependenciesConfiguration(),
-                        builder -> builder.setVersion(runtime.getSpecification().getNeoFormVersion()),
-                        builder -> builder.setVersion(runtime.getSpecification().getNeoFormVersion()),
+                        builder -> builder.setVersion(runtime.getSpecification().getVersion()),
+                        builder -> builder.setVersion(runtime.getSpecification().getVersion()),
                         runtime::setReplacedDependency,
                         runtime::onRepoWritten,
                         Sets::newHashSet

--- a/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/specification/NeoFormRuntimeSpecification.java
+++ b/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/specification/NeoFormRuntimeSpecification.java
@@ -52,9 +52,9 @@ public class NeoFormRuntimeSpecification extends CommonRuntimeSpecification impl
     public String getMinecraftVersion() {
         return config.getVersion();
     }
-    
+
     public String getNeoFormVersion() {
-        return getVersion();
+        return getVersion().substring(getVersion().lastIndexOf("-") + 1);
     }
 
     public File getNeoFormArchive() {

--- a/platform/src/main/java/net/neoforged/gradle/platform/extensions/DynamicProjectExtension.java
+++ b/platform/src/main/java/net/neoforged/gradle/platform/extensions/DynamicProjectExtension.java
@@ -167,7 +167,7 @@ public abstract class DynamicProjectExtension implements BaseDSLElement<DynamicP
         });
         // The NeoForm version that's passed into this method can be a version range or '+', but to build userdev and installer profiles safely,
         // we need the actual version it was resolved to. Otherwise the NeoForm version used by installer & userdev could change over time.
-        String neoformDependency = "net.neoforged:neoform:" + neoFormRuntimeDefinition.getSpecification().getNeoFormVersion() + "@zip";
+        String neoformDependency = "net.neoforged:neoform:" + neoFormRuntimeDefinition.getSpecification().getVersion() + "@zip";
 
         final RuntimeDevRuntimeExtension runtimeDevRuntimeExtension = project.getExtensions().getByType(RuntimeDevRuntimeExtension.class);
         final RuntimeDevRuntimeDefinition runtimeDefinition = runtimeDevRuntimeExtension.create(builder -> {


### PR DESCRIPTION
PR #86 caused a change in the behavior of `NeoFormRuntimeSpecification#getNeoFormVersion`, in which it now returns versions in the form `MCVERSION-TIMESTAMP` instead of `TIMESTAMP`. This PR fixes this regression, and updates locations which make use of the new behavior to use `Specification#getVersion` instead, which returns the full MC-version-and-timestamp version string, as well as adding something to the javadoc of the method explaining which form is should return. I have tested this in neodev, and it creates an installer which works, and which can launch the game as a dedicated server successfully.