### PR TITLE
Make NeoFormRuntimeSpecification#getNeoFormVersion work with suffixed neoform versions

### DIFF
--- a/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/specification/NeoFormRuntimeSpecification.java
+++ b/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/specification/NeoFormRuntimeSpecification.java
@@ -54,7 +54,12 @@ public class NeoFormRuntimeSpecification extends CommonRuntimeSpecification impl
     }
 
     public String getNeoFormVersion() {
-        return getVersion().substring(getVersion().lastIndexOf("-") + 1);
+        String prefix = getMinecraftVersion() + "-";
+        if (getVersion().startsWith(prefix)) {
+            return getVersion().substring(prefix.length());
+        } else {
+            throw new RuntimeException("NeoForm version " + getVersion() + " does not start with Minecraft version" + getMinecraftVersion());
+        }
     }
 
     public File getNeoFormArchive() {


### PR DESCRIPTION
Should allow NG to work with neoform versions such as `1.20.4-20231222.062341-unpick`, as discussed on discord