### PR TITLE
Fix TokenizedTask passing Objects directly to ReplaceTokens

### DIFF
--- a/platform/src/main/java/net/neoforged/gradle/platform/tasks/CreateClasspathFiles.java
+++ b/platform/src/main/java/net/neoforged/gradle/platform/tasks/CreateClasspathFiles.java
@@ -33,7 +33,7 @@ public abstract class CreateClasspathFiles extends DefaultRuntime implements Tok
     
     @TaskAction
     public void doTask() throws Exception {
-        final Map<String, Object> tokens = new HashMap<>(getTokens().get());
+        final Map<String, String> tokens = new HashMap<>(getTokens().get());
         
         ArtifactPathsCollector modulePathCollector = new ArtifactPathsCollector(getObjectFactory(), getPathSeparator().get(), "libraries/");
         ArtifactPathsCollector classpathCollector = new ArtifactPathsCollector(getObjectFactory(), getPathSeparator().get(), "libraries/");

--- a/platform/src/main/java/net/neoforged/gradle/platform/tasks/CreateLegacyInstaller.java
+++ b/platform/src/main/java/net/neoforged/gradle/platform/tasks/CreateLegacyInstaller.java
@@ -63,9 +63,9 @@ public abstract class CreateLegacyInstaller extends Zip implements WithOutput, W
         from(getData(), spec -> {
             spec.into("data");
             spec.filter(s -> {
-                final Map<String, Object> tokens = getTokens().get();
-                for (Map.Entry<String, Object> entry : tokens.entrySet()) {
-                    s = s.replace(String.format("@%s@", entry.getKey()), entry.getValue().toString());
+                final Map<String, String> tokens = getTokens().get();
+                for (Map.Entry<String, String> entry : tokens.entrySet()) {
+                    s = s.replace(String.format("@%s@", entry.getKey()), entry.getValue());
                 }
                 return s;
             });

--- a/platform/src/main/java/net/neoforged/gradle/platform/tasks/TokenizedTask.java
+++ b/platform/src/main/java/net/neoforged/gradle/platform/tasks/TokenizedTask.java
@@ -8,13 +8,13 @@ import org.gradle.api.tasks.Input;
 public interface TokenizedTask extends Task {
     
     @Input
-    MapProperty<String, Object> getTokens();
+    MapProperty<String, String> getTokens();
     
     default void token(String key, Object value) {
-        getTokens().put(key, value);
+        getTokens().put(key, value.toString());
     }
     
     default void token(String key, Provider<?> value) {
-        getTokens().put(key, value);
+        getTokens().put(key, value.map(Object::toString));
     }
 }


### PR DESCRIPTION
If you look at `ReplaceTokens`, it requires a `Map<String, String>`. However we feed it a `Map<String, Object>`. This fixes weird build failures in token substitution when using a GString project version.