### PR TITLE
Make CoordinateCollector deterministic

### DIFF
--- a/dsl/platform/src/main/groovy/net/neoforged/gradle/dsl/platform/util/CoordinateCollector.groovy
+++ b/dsl/platform/src/main/groovy/net/neoforged/gradle/dsl/platform/util/CoordinateCollector.groovy
@@ -1,14 +1,13 @@
 package net.neoforged.gradle.dsl.platform.util
 
 import groovy.transform.CompileStatic
-import net.neoforged.gradle.dsl.platform.util.ModuleIdentificationVisitor
 import org.gradle.api.model.ObjectFactory
 import org.jetbrains.annotations.Nullable
 
 @CompileStatic
 class CoordinateCollector extends ModuleIdentificationVisitor {
 
-    private final Set<String> coordinates = new HashSet<>()
+    private final Set<String> coordinates = new LinkedHashSet<>(); // Ensure deterministic ordering
 
     CoordinateCollector(ObjectFactory objectFactory) {
         super(objectFactory)


### PR DESCRIPTION
This should increase determinism in the legacy class path, making issues easier to diagnose.