### PR TITLE
Depend on GDI via capability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,9 +90,11 @@ subprojects.forEach { Project subProject ->
     //Basic dependencies: Jetbrains Annotations, JUnit and Mockito for now.
     subProject.dependencies.api subProject.dependencies.gradleApi()
     subProject.dependencies.api "org.jetbrains:annotations:${project.jetbrains_annotations_version}"
-    subProject.dependencies.api "net.neoforged:groovydslimprover:${project.groovy_dsl_improver_version}"
-    subProject.dependencies.api "net.neoforged:groovydslimprover:${project.groovy_dsl_improver_version}:base"
-    subProject.dependencies.api "net.neoforged:groovydslimprover:${project.groovy_dsl_improver_version}:runtime"
+    subProject.dependencies.api("net.neoforged:groovydslimprover:${project.groovy_dsl_improver_version}") {
+        capabilities {
+            requireCapability 'net.neoforged:groovydslimprover-base'
+        }
+    }
 
     subProject.dependencies.testImplementation subProject.dependencies.gradleTestKit()
     subProject.dependencies.testImplementation "org.junit.jupiter:junit-jupiter-api:${project.junit_version}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,7 +29,7 @@ diffpatch_version=1.5.0.29
 jarjar_version=0.4.1
 jetbrains_annotations_version=23.0.0
 gradle_idea_extension_version=1.1.6
-groovy_dsl_improver_version=1.0.13
+groovy_dsl_improver_version=1.0.15
 eclipse_launch_configs_version=0.1.3
 
 #Test dependencies


### PR DESCRIPTION
With GDI 1.0.15, proper capability dependencies are published; depending on GDI via capability allows for gradle to be a bit smarter when picking variants.