### PR TITLE
Use correct installer library repository urls

### DIFF
--- a/dsl/platform/src/main/groovy/net/neoforged/gradle/dsl/platform/model/InstallerProfile.groovy
+++ b/dsl/platform/src/main/groovy/net/neoforged/gradle/dsl/platform/model/InstallerProfile.groovy
@@ -19,6 +19,7 @@ import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
@@ -33,6 +34,7 @@ import javax.inject.Inject
 import java.lang.reflect.Type
 import java.util.function.BiConsumer
 import java.util.function.BiFunction
+import java.util.stream.Collectors
 
 import static net.neoforged.gradle.dsl.common.util.PropertyUtils.deserializeBool
 import static net.neoforged.gradle.dsl.common.util.PropertyUtils.deserializeList
@@ -190,7 +192,8 @@ abstract class InstallerProfile implements ConfigurableDSLElement<InstallerProfi
                 final Dependency[] dependencies = dependencyCoordinates.stream().map { coord -> project.getDependencies().create(coord) }.toArray(Dependency[]::new)
                 final Configuration configuration = ConfigurationUtils.temporaryConfiguration(project, dependencies)
 
-                final LibraryCollector collector = new LibraryCollector(project.getObjects())
+                final LibraryCollector collector = new LibraryCollector(project.getObjects(), project.getRepositories()
+                    .withType(MavenArtifactRepository).stream().map { it.url }.collect(Collectors.toList()))
                 configuration.getAsFileTree().visit collector
                 return collector.getLibraries()
             }

--- a/dsl/platform/src/main/groovy/net/neoforged/gradle/dsl/platform/util/LibraryCollector.groovy
+++ b/dsl/platform/src/main/groovy/net/neoforged/gradle/dsl/platform/util/LibraryCollector.groovy
@@ -37,7 +37,6 @@ class LibraryCollector extends ModuleIdentificationVisitor {
         String url = getMavenServerFor(path) + "/" + path;
         int pos = 0
         while (attemptConnection(url) !== 200 && pos < repositoryUrls.size()) {
-            println("url request ${url}: ${attemptConnection(url)}")
             url = repositoryUrls.get(pos++).resolve(path).toString()
         }
 

--- a/dsl/platform/src/main/groovy/net/neoforged/gradle/dsl/platform/util/LibraryCollector.groovy
+++ b/dsl/platform/src/main/groovy/net/neoforged/gradle/dsl/platform/util/LibraryCollector.groovy
@@ -14,12 +14,14 @@ import java.nio.file.Files
 class LibraryCollector extends ModuleIdentificationVisitor {
 
     private final ObjectFactory objectFactory;
+    private final List<URI> repositoryUrls
 
     private final List<Library> libraries = new ArrayList<>();
 
-    LibraryCollector(ObjectFactory objectFactory) {
+    LibraryCollector(ObjectFactory objectFactory, List<URI> repoUrl) {
         super(objectFactory);
         this.objectFactory = objectFactory;
+        this.repositoryUrls = repoUrl
     }
 
     @Override
@@ -32,7 +34,13 @@ class LibraryCollector extends ModuleIdentificationVisitor {
         download.getArtifact().set(artifact);
 
         final String path = group.replace(".", "/") + "/" + module + "/" + version + "/" + module + "-" + version + (classifier.isEmpty() ? "" : "-" + classifier) + "." + extension;
-        final String url = getMavenServerFor(path) + "/" + path;
+        String url = getMavenServerFor(path) + "/" + path;
+        int pos = 0
+        while (attemptConnection(url) !== 200 && pos < repositoryUrls.size()) {
+            println("url request ${url}: ${attemptConnection(url)}")
+            url = repositoryUrls.get(pos++).resolve(path).toString()
+        }
+
         final String name = group + ":" + module + ":" + version + (classifier.isEmpty() ? "" : ":" + classifier) + "@" + extension;
 
         library.getName().set(name);
@@ -46,6 +54,19 @@ class LibraryCollector extends ModuleIdentificationVisitor {
         }
 
         libraries.add(library);
+    }
+
+    private static int attemptConnection(String url) {
+        try {
+            final conn = (HttpURLConnection) url.toURL().openConnection()
+            conn.setRequestMethod('HEAD')
+            conn.connect()
+            int rc = conn.responseCode
+            conn.disconnect()
+            return rc
+        } catch (Exception ignored) {
+            return 404
+        }
     }
 
     private static String getMavenServerFor(String path) {

--- a/dsl/platform/src/main/groovy/net/neoforged/gradle/dsl/platform/util/RepositoryCollection.java
+++ b/dsl/platform/src/main/groovy/net/neoforged/gradle/dsl/platform/util/RepositoryCollection.java
@@ -1,0 +1,22 @@
+package net.neoforged.gradle.dsl.platform.util;
+
+import org.gradle.api.artifacts.dsl.RepositoryHandler;
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.ProviderFactory;
+
+import java.net.URI;
+
+public class RepositoryCollection {
+    private final ListProperty<URI> urls;
+
+    public RepositoryCollection(ProviderFactory providers, ObjectFactory objects, RepositoryHandler handler) {
+        this.urls = objects.listProperty(URI.class);
+        handler.withType(MavenArtifactRepository.class).configureEach(repo -> urls.add(providers.provider(repo::getUrl)));
+    }
+
+    public ListProperty<URI> getURLs() {
+        return urls;
+    }
+}

--- a/platform/src/main/java/net/neoforged/gradle/platform/extensions/DynamicProjectExtension.java
+++ b/platform/src/main/java/net/neoforged/gradle/platform/extensions/DynamicProjectExtension.java
@@ -30,6 +30,7 @@ import net.neoforged.gradle.dsl.common.util.*;
 import net.neoforged.gradle.dsl.platform.model.InstallerProfile;
 import net.neoforged.gradle.dsl.platform.model.LauncherProfile;
 import net.neoforged.gradle.dsl.platform.model.Library;
+import net.neoforged.gradle.dsl.platform.util.RepositoryCollection;
 import net.neoforged.gradle.dsl.userdev.configurations.UserdevProfile;
 import net.neoforged.gradle.neoform.NeoFormProjectPlugin;
 import net.neoforged.gradle.neoform.runtime.definition.NeoFormRuntimeDefinition;
@@ -62,6 +63,7 @@ import org.gradle.api.file.Directory;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
@@ -74,6 +76,7 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.inject.Inject;
 import java.io.File;
+import java.net.URI;
 import java.nio.file.Files;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -324,13 +327,15 @@ public abstract class DynamicProjectExtension implements BaseDSLElement<DynamicP
                 
                 launcherProfile.getArguments().set(arguments);
             });
-            
+
+            final ListProperty<URI> repoCollection = new RepositoryCollection(project.getProviders(), project.getObjects(), project.getRepositories()).getURLs();
             final TaskProvider<CreateLauncherJson> createLauncherJson = project.getTasks().register("createLauncherJson", CreateLauncherJson.class, task -> {
                 task.getProfile().set(launcherProfile);
                 task.getLibraries().from(installerConfiguration);
                 task.getLibraries().from(pluginLayerLibraryConfiguration);
                 task.getLibraries().from(gameLayerLibraryConfiguration);
                 task.getLibraries().from(moduleOnlyConfiguration);
+                task.getRepositoryURLs().set(repoCollection);
                 
                 CommonRuntimeExtension.configureCommonRuntimeTaskParameters(task, runtimeDefinition, workingDirectory);
             });
@@ -461,6 +466,7 @@ public abstract class DynamicProjectExtension implements BaseDSLElement<DynamicP
             final TaskProvider<CreateLegacyInstallerJson> createLegacyInstallerJson = project.getTasks().register("createLegacyInstallerJson", CreateLegacyInstallerJson.class, task -> {
                 task.getProfile().set(installerProfile);
                 task.getLibraries().from(installerLibrariesConfiguration);
+                task.getRepositoryURLs().set(repoCollection);
                 
                 task.dependsOn(signUniversalJar);
                 

--- a/platform/src/main/java/net/neoforged/gradle/platform/tasks/CreateLauncherJson.java
+++ b/platform/src/main/java/net/neoforged/gradle/platform/tasks/CreateLauncherJson.java
@@ -7,12 +7,15 @@ import net.neoforged.gradle.dsl.common.tasks.WithWorkspace;
 import net.neoforged.gradle.dsl.platform.model.LauncherProfile;
 import net.neoforged.gradle.dsl.platform.util.LibraryCollector;
 import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.*;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.URI;
+import java.net.URL;
 import java.nio.file.Files;
 
 @CacheableTask
@@ -32,7 +35,7 @@ public abstract class CreateLauncherJson extends DefaultRuntime implements WithO
         
         clone.getLibraries().addAll(
                 getProviderFactory().provider(() -> {
-                    final LibraryCollector profileFiller = new LibraryCollector(getObjectFactory());
+                    final LibraryCollector profileFiller = new LibraryCollector(getObjectFactory(), getRepositoryURLs().get());
                     getLibraries().getAsFileTree().visit(profileFiller);
                     return profileFiller.getLibraries();
                 })
@@ -53,4 +56,7 @@ public abstract class CreateLauncherJson extends DefaultRuntime implements WithO
     @InputFiles
     @PathSensitive(PathSensitivity.NONE)
     public abstract ConfigurableFileCollection getLibraries();
+
+    @Input
+    public abstract ListProperty<URI> getRepositoryURLs();
 }

--- a/platform/src/main/java/net/neoforged/gradle/platform/tasks/CreateLegacyInstallerJson.java
+++ b/platform/src/main/java/net/neoforged/gradle/platform/tasks/CreateLegacyInstallerJson.java
@@ -7,12 +7,14 @@ import net.neoforged.gradle.dsl.common.tasks.WithWorkspace;
 import net.neoforged.gradle.dsl.platform.model.InstallerProfile;
 import net.neoforged.gradle.dsl.platform.util.LibraryCollector;
 import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.*;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.URI;
 import java.nio.file.Files;
 
 @CacheableTask
@@ -32,7 +34,7 @@ public abstract class CreateLegacyInstallerJson extends DefaultRuntime implement
         
         copy.getLibraries().addAll(
                 getProviderFactory().provider(() -> {
-                    final LibraryCollector profileFiller = new LibraryCollector(getObjectFactory());
+                    final LibraryCollector profileFiller = new LibraryCollector(getObjectFactory(), getRepositoryURLs().get());
                     getLibraries().getAsFileTree().visit(profileFiller);
                     return profileFiller.getLibraries();
                 })
@@ -44,10 +46,13 @@ public abstract class CreateLegacyInstallerJson extends DefaultRuntime implement
         }
     }
     
-    @Nested
+    @Internal
     public abstract Property<InstallerProfile> getProfile();
     
     @InputFiles
     @PathSensitive(PathSensitivity.NONE)
     public abstract ConfigurableFileCollection getLibraries();
+
+    @Input
+    public abstract ListProperty<URI> getRepositoryURLs();
 }


### PR DESCRIPTION
This allows building installers that use other repositories, like PR publishing repositories.