### PR TITLE
Make jarJar configuration not consumable

### DIFF
--- a/common/src/main/java/net/neoforged/gradle/common/extensions/DefaultJarJarFeature.java
+++ b/common/src/main/java/net/neoforged/gradle/common/extensions/DefaultJarJarFeature.java
@@ -119,6 +119,8 @@ public class DefaultJarJarFeature implements JarJarFeature {
         configuration.getAllDependencies().configureEach(dep ->
                 this.enable()
         );
+        // jarJar configurations should be resolvable, but ought not to be exposed to consumers;
+        // as it has attributes, it could conflict with normal exposed configurations
         configuration.setCanBeResolved(true);
         configuration.setCanBeConsumed(false);
 

--- a/common/src/main/java/net/neoforged/gradle/common/extensions/DefaultJarJarFeature.java
+++ b/common/src/main/java/net/neoforged/gradle/common/extensions/DefaultJarJarFeature.java
@@ -119,6 +119,8 @@ public class DefaultJarJarFeature implements JarJarFeature {
         configuration.getAllDependencies().configureEach(dep ->
                 this.enable()
         );
+        configuration.setCanBeResolved(true);
+        configuration.setCanBeConsumed(false);
 
         JavaPluginExtension javaPlugin = project.getExtensions().getByType(JavaPluginExtension.class);
 


### PR DESCRIPTION
Currently, the `jarJar` configuration is consumable. As it has attributes, this can lead to weirdness when consuming a project that uses jarJar via a project dependency. This fixes that; the configuration has no need to be consumable.