### PR TITLE
Fix unused mcp_mappings placeholder causing problems

### DIFF
--- a/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/definition/NeoFormRuntimeDefinition.java
+++ b/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/definition/NeoFormRuntimeDefinition.java
@@ -102,9 +102,9 @@ public class NeoFormRuntimeDefinition extends CommonRuntimeDefinition<NeoFormRun
         final Map<String, String> interpolationData = new HashMap<>(super.buildRunInterpolationData(run));
 
         interpolationData.put("mcp_version", neoform.getVersion());
-        interpolationData.put("mcp_mappings", getSpecification().getNeoFormArchive()
-                .matching(artifact -> artifact.include("config/joined.srg"))
-                .getSingleFile().getAbsolutePath());
+        // NeoForge still references this in the environment variable MCP_MAPPINGS, which is unused since 1.20.2
+        // Remove this interpolation placeholder once NeoForge removes the environment variable from its config.json
+        interpolationData.put("mcp_mappings", "UNUSED_DEPRECATED");
         return interpolationData;
     }
 


### PR DESCRIPTION
Previously we set the unused mcp_mappings placeholder to a file that doesn't exist. Gradle now checks the file we try to resolve actually exists and crashes.

Fixes #150 