### PR TITLE
Remove MCP_MAPPINGS from the generated Neoforge run types

### DIFF
--- a/platform/src/main/java/net/neoforged/gradle/platform/extensions/DynamicProjectExtension.java
+++ b/platform/src/main/java/net/neoforged/gradle/platform/extensions/DynamicProjectExtension.java
@@ -538,8 +538,7 @@ public abstract class DynamicProjectExtension implements BaseDSLElement<DynamicP
             //Note: We can not use a 'configureEach' here, because this causes issues with the config cache.
             userdevProfile.runType("client", type -> {
                 type.getEnvironmentVariables().put("MOD_CLASSES", "{source_roots}");
-                type.getEnvironmentVariables().put("MCP_MAPPINGS", "{mcp_mappings}");
-                
+
                 type.getIsClient().set(true);
                 type.getIsGameTest().set(true);
                 type.getSystemProperties().put("neoforge.enableGameTest", "true");
@@ -557,8 +556,7 @@ public abstract class DynamicProjectExtension implements BaseDSLElement<DynamicP
             });
             userdevProfile.runType("server", type -> {
                 type.getEnvironmentVariables().put("MOD_CLASSES", "{source_roots}");
-                type.getEnvironmentVariables().put("MCP_MAPPINGS", "{mcp_mappings}");
-                
+
                 type.getIsServer().set(true);
                 
                 type.getArguments().add("--launchTarget");
@@ -568,8 +566,7 @@ public abstract class DynamicProjectExtension implements BaseDSLElement<DynamicP
             });
             userdevProfile.runType("gameTestServer", type -> {
                 type.getEnvironmentVariables().put("MOD_CLASSES", "{source_roots}");
-                type.getEnvironmentVariables().put("MCP_MAPPINGS", "{mcp_mappings}");
-                
+
                 type.getIsServer().set(true);
                 type.getIsGameTest().set(true);
                 type.getSystemProperties().put("neoforge.enableGameTest", "true");
@@ -583,8 +580,7 @@ public abstract class DynamicProjectExtension implements BaseDSLElement<DynamicP
             });
             userdevProfile.runType("data", type -> {
                 type.getEnvironmentVariables().put("MOD_CLASSES", "{source_roots}");
-                type.getEnvironmentVariables().put("MCP_MAPPINGS", "{mcp_mappings}");
-                
+
                 type.getIsDataGenerator().set(true);
                 
                 type.getArguments().add("--launchTarget");


### PR DESCRIPTION
The MCP_MAPPINGS environment variable is not actually used anymore since 1.20.2
p.s.: Settings the interpolation variable for runs can not be removed yet until a Neoforge version is published with a NeoGradle version that has the changes in this PR.