### PR TITLE
Fix long-form Vineflower log and thread arguments not getting recognized

### DIFF
--- a/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/extensions/NeoFormRuntimeExtension.java
+++ b/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/extensions/NeoFormRuntimeExtension.java
@@ -169,7 +169,7 @@ public abstract class NeoFormRuntimeExtension extends CommonRuntimeExtension<Neo
 
         // Filter out decompiler arguments that aren't related to its output (log-level and thread-count)
         List<String> decompilerArgs = new ArrayList<>(function.getArgs());
-        decompilerArgs.removeIf(arg -> arg.startsWith("-log=") || arg.startsWith("-thr="));
+        decompilerArgs.removeIf(arg -> arg.startsWith("--log-level") || arg.startsWith("-log=") || arg.startsWith("--thread-count") || arg.startsWith("-thr="));
 
         // Retrieve the default memory size from the JVM arguments configured in NeoForm
         String defaultMaxMemory = "4g";


### PR DESCRIPTION
NeoForm switched to using `--log-level` instead of `-log` to specify TRACE for Vineflower.
This prevents NeoGradle from overriding it, since we currently only look for `-log`.