### PR TITLE
Fix installer URLs without a trailing slash

### DIFF
--- a/dsl/platform/src/main/groovy/net/neoforged/gradle/dsl/platform/util/RepositoryCollection.java
+++ b/dsl/platform/src/main/groovy/net/neoforged/gradle/dsl/platform/util/RepositoryCollection.java
@@ -13,10 +13,16 @@ public class RepositoryCollection {
 
     public RepositoryCollection(ProviderFactory providers, ObjectFactory objects, RepositoryHandler handler) {
         this.urls = objects.listProperty(URI.class);
-        handler.withType(MavenArtifactRepository.class).configureEach(repo -> urls.add(providers.provider(repo::getUrl)));
+        handler.withType(MavenArtifactRepository.class).configureEach(repo -> urls.add(providers.provider(repo::getUrl).map(RepositoryCollection::addLeadingSlash)));
     }
 
     public ListProperty<URI> getURLs() {
         return urls;
+    }
+
+    private static URI addLeadingSlash(URI uri) {
+        String asString = uri.toString();
+        if (asString.endsWith("/")) return uri;
+        return URI.create(asString + "/");
     }
 }

--- a/dsl/platform/src/main/groovy/net/neoforged/gradle/dsl/platform/util/RepositoryCollection.java
+++ b/dsl/platform/src/main/groovy/net/neoforged/gradle/dsl/platform/util/RepositoryCollection.java
@@ -13,14 +13,14 @@ public class RepositoryCollection {
 
     public RepositoryCollection(ProviderFactory providers, ObjectFactory objects, RepositoryHandler handler) {
         this.urls = objects.listProperty(URI.class);
-        handler.withType(MavenArtifactRepository.class).configureEach(repo -> urls.add(providers.provider(repo::getUrl).map(RepositoryCollection::addLeadingSlash)));
+        handler.withType(MavenArtifactRepository.class).configureEach(repo -> urls.add(providers.provider(repo::getUrl).map(RepositoryCollection::addTrailingSlash)));
     }
 
     public ListProperty<URI> getURLs() {
         return urls;
     }
 
-    private static URI addLeadingSlash(URI uri) {
+    private static URI addTrailingSlash(URI uri) {
         String asString = uri.toString();
         if (asString.endsWith("/")) return uri;
         return URI.create(asString + "/");


### PR DESCRIPTION
`URI#resolve` is stupid.