### PR TITLE
Avoid deleting dummy repository files unless needed

### DIFF
--- a/common/src/main/java/net/neoforged/gradle/common/extensions/repository/IvyDummyRepositoryExtension.java
+++ b/common/src/main/java/net/neoforged/gradle/common/extensions/repository/IvyDummyRepositoryExtension.java
@@ -169,13 +169,13 @@ public abstract class IvyDummyRepositoryExtension implements ConfigurableDSLElem
         writeIvyMetadataFile(entry, jarFile, baseDir, metaFile);
 
         if (!Files.isRegularFile(jarFile)) {
-            Files.deleteIfExists(jarFile);
+            FileUtils.delete(jarFile);
             Files.createFile(jarFile);
         }
 
         final Path sourcesFile = entry.asSources().buildArtifactPath(getRepositoryDirectory().get().getAsFile().toPath());
         if (!Files.isRegularFile(sourcesFile)) {
-            Files.deleteIfExists(sourcesFile);
+            FileUtils.delete(sourcesFile);
             Files.createFile(sourcesFile);
         }
 

--- a/common/src/main/java/net/neoforged/gradle/common/extensions/repository/IvyDummyRepositoryExtension.java
+++ b/common/src/main/java/net/neoforged/gradle/common/extensions/repository/IvyDummyRepositoryExtension.java
@@ -168,12 +168,16 @@ public abstract class IvyDummyRepositoryExtension implements ConfigurableDSLElem
 
         writeIvyMetadataFile(entry, jarFile, baseDir, metaFile);
 
-        Files.deleteIfExists(jarFile);
-        Files.createFile(jarFile);
+        if (!Files.isRegularFile(jarFile)) {
+            Files.deleteIfExists(jarFile);
+            Files.createFile(jarFile);
+        }
 
         final Path sourcesFile = entry.asSources().buildArtifactPath(getRepositoryDirectory().get().getAsFile().toPath());
-        Files.deleteIfExists(sourcesFile);
-        Files.createFile(sourcesFile);
+        if (!Files.isRegularFile(sourcesFile)) {
+            Files.deleteIfExists(sourcesFile);
+            Files.createFile(sourcesFile);
+        }
 
         writeDummyDependencyDataIfNeeded(entry);
     }


### PR DESCRIPTION
This practice not only breaks caching, but also causes issues with concurrent invocations of Gradle tasks (i.e. IDE refresh).