### PR TITLE
Slight simplification of dep replacement

### DIFF
--- a/common/src/test/java/net/neoforged/gradle/common/extensions/dependency/replacement/DependencyReplacementsExtensionTest.java
+++ b/common/src/test/java/net/neoforged/gradle/common/extensions/dependency/replacement/DependencyReplacementsExtensionTest.java
@@ -225,9 +225,7 @@ public class DependencyReplacementsExtensionTest {
         dependencyReplacementsExtension.handleDependencyReplacement(
                 configuration,
                 mock(ProjectDependency.class),
-                mock(DependencyReplacementResult.class),
-                mock(DependencyReplacementsExtension.DependencyReplacer.class),
-                mock(DependencyReplacementsExtension.DependencyReplacer.class)
+                mock(DependencyReplacementResult.class)
         );
 
         verify(dependencySet).remove(any());
@@ -268,9 +266,7 @@ public class DependencyReplacementsExtensionTest {
         dependencyReplacementsExtension.handleDependencyReplacement(
                 configuration,
                 mock(ProjectDependency.class),
-                mock(DependencyReplacementResult.class),
-                mock(DependencyReplacementsExtension.DependencyReplacer.class),
-                mock(DependencyReplacementsExtension.DependencyReplacer.class)
+                mock(DependencyReplacementResult.class)
         );
 
         verify(dependencySet).whenObjectAdded((Action<? super Dependency>) any());
@@ -307,9 +303,7 @@ public class DependencyReplacementsExtensionTest {
         dependencyReplacementsExtension.handleDependencyReplacement(
                 configuration,
                 mock(ProjectDependency.class),
-                mock(DependencyReplacementResult.class),
-                mock(DependencyReplacementsExtension.DependencyReplacer.class),
-                mock(DependencyReplacementsExtension.DependencyReplacer.class)
+                mock(DependencyReplacementResult.class)
         );
 
         verify(dependencySet, never()).add(any());
@@ -345,128 +339,6 @@ public class DependencyReplacementsExtensionTest {
         final DependencyReplacementsExtension dependencyReplacementsExtension = new SystemUnderTest(project, dependencyCreator);
 
         verify(dependencySet).whenObjectAdded((Action<? super Dependency>) any());
-    }
-
-    @Test
-    public void callingHandleDependencyReplacementAlwaysInvokesTheGradleReplacementHandler() {
-        final Project project = mock(Project.class);
-        final ExtensionContainer extensionContainer = mock(ExtensionContainer.class);
-        final TaskContainer taskContainer = mock(TaskContainer.class);
-        final ObjectFactory objectFactory = mock(ObjectFactory.class);
-        final ConfigurationContainer configurationContainer = mock(ConfigurationContainer.class);
-        final Configuration configuration = mock(Configuration.class);
-        final DependencySet dependencySet = mock(DependencySet.class);
-        final Repository<?> repository = mock(Repository.class);
-        final IdeManagementExtension ideManagementExtension = mock(IdeManagementExtension.class);
-        final DependencyCreator dependencyCreator = mock(DependencyCreator.class);
-        final DependencyReplacementsExtension.DependencyReplacer gradleReplacementHandler = mock(DependencyReplacementsExtension.DependencyReplacer.class);
-
-        when(project.getExtensions()).thenReturn(extensionContainer);
-        when(extensionContainer.getByType(Repository.class)).thenReturn(repository);
-        when(extensionContainer.getByType(IdeManagementExtension.class)).thenReturn(ideManagementExtension);
-        when(project.getConfigurations()).thenReturn(configurationContainer);
-        when(project.getTasks()).thenReturn(taskContainer);
-        when(project.getObjects()).thenReturn(objectFactory);
-        when(configuration.getDependencies()).thenReturn(dependencySet);
-        doAnswer(invocation -> {
-            final Action<Configuration> configurationAction = invocation.getArgument(0);
-            configurationAction.execute(configuration);
-            return null;
-        }).when(configurationContainer).configureEach(any());
-
-        final DependencyReplacementsExtension dependencyReplacementsExtension = new SystemUnderTest(project, dependencyCreator);
-
-        dependencyReplacementsExtension.handleDependencyReplacement(
-                configuration,
-                mock(ProjectDependency.class),
-                mock(DependencyReplacementResult.class),
-                mock(DependencyReplacementsExtension.DependencyReplacer.class),
-                gradleReplacementHandler
-        );
-
-        verify(gradleReplacementHandler).handle(any(), any(), any(), any());
-    }
-
-    @Test
-    public void callingHandleDependencyReplacementAlwaysInvokesTheIdeReplacementHandlerWhenAnImportIsRunning() {
-        final Project project = mock(Project.class);
-        final ExtensionContainer extensionContainer = mock(ExtensionContainer.class);
-        final TaskContainer taskContainer = mock(TaskContainer.class);
-        final ObjectFactory objectFactory = mock(ObjectFactory.class);
-        final ConfigurationContainer configurationContainer = mock(ConfigurationContainer.class);
-        final Configuration configuration = mock(Configuration.class);
-        final DependencySet dependencySet = mock(DependencySet.class);
-        final Repository<?> repository = mock(Repository.class);
-        final IdeManagementExtension ideManagementExtension = mock(IdeManagementExtension.class);
-        final DependencyCreator dependencyCreator = mock(DependencyCreator.class);
-        final DependencyReplacementsExtension.DependencyReplacer ideReplacementHandler = mock(DependencyReplacementsExtension.DependencyReplacer.class);
-
-        when(project.getExtensions()).thenReturn(extensionContainer);
-        when(extensionContainer.getByType(Repository.class)).thenReturn(repository);
-        when(extensionContainer.getByType(IdeManagementExtension.class)).thenReturn(ideManagementExtension);
-        when(project.getConfigurations()).thenReturn(configurationContainer);
-        when(project.getTasks()).thenReturn(taskContainer);
-        when(project.getObjects()).thenReturn(objectFactory);
-        when(configuration.getDependencies()).thenReturn(dependencySet);
-        doAnswer(invocation -> {
-            final Action<Configuration> configurationAction = invocation.getArgument(0);
-            configurationAction.execute(configuration);
-            return null;
-        }).when(configurationContainer).configureEach(any());
-        when(ideManagementExtension.isIdeImportInProgress()).thenReturn(true);
-
-        final DependencyReplacementsExtension dependencyReplacementsExtension = new SystemUnderTest(project, dependencyCreator);
-
-        dependencyReplacementsExtension.handleDependencyReplacement(
-                configuration,
-                mock(ProjectDependency.class),
-                mock(DependencyReplacementResult.class),
-                ideReplacementHandler,
-                mock(DependencyReplacementsExtension.DependencyReplacer.class)
-        );
-
-        verify(ideReplacementHandler).handle(any(), any(), any(), any());
-    }
-
-    @Test
-    public void callingHandleDependencyReplacementAlwaysInvokesTheIdeReplacementHandlerWhenNoImportIsRunning() {
-        final Project project = mock(Project.class);
-        final ExtensionContainer extensionContainer = mock(ExtensionContainer.class);
-        final TaskContainer taskContainer = mock(TaskContainer.class);
-        final ObjectFactory objectFactory = mock(ObjectFactory.class);
-        final ConfigurationContainer configurationContainer = mock(ConfigurationContainer.class);
-        final Configuration configuration = mock(Configuration.class);
-        final DependencySet dependencySet = mock(DependencySet.class);
-        final Repository<?> repository = mock(Repository.class);
-        final IdeManagementExtension ideManagementExtension = mock(IdeManagementExtension.class);
-        final DependencyCreator dependencyCreator = mock(DependencyCreator.class);
-        final DependencyReplacementsExtension.DependencyReplacer ideReplacementHandler = mock(DependencyReplacementsExtension.DependencyReplacer.class);
-
-        when(project.getExtensions()).thenReturn(extensionContainer);
-        when(extensionContainer.getByType(Repository.class)).thenReturn(repository);
-        when(extensionContainer.getByType(IdeManagementExtension.class)).thenReturn(ideManagementExtension);
-        when(project.getConfigurations()).thenReturn(configurationContainer);
-        when(project.getTasks()).thenReturn(taskContainer);
-        when(project.getObjects()).thenReturn(objectFactory);
-        when(configuration.getDependencies()).thenReturn(dependencySet);
-        doAnswer(invocation -> {
-            final Action<Configuration> configurationAction = invocation.getArgument(0);
-            configurationAction.execute(configuration);
-            return null;
-        }).when(configurationContainer).configureEach(any());
-        when(ideManagementExtension.isIdeImportInProgress()).thenReturn(false);
-
-        final DependencyReplacementsExtension dependencyReplacementsExtension = new SystemUnderTest(project, dependencyCreator);
-
-        dependencyReplacementsExtension.handleDependencyReplacement(
-                configuration,
-                mock(ProjectDependency.class),
-                mock(DependencyReplacementResult.class),
-                ideReplacementHandler,
-                mock(DependencyReplacementsExtension.DependencyReplacer.class)
-        );
-
-        verify(ideReplacementHandler, never()).handle(any(), any(), any(), any());
     }
 
     @Test

--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/extensions/dependency/replacement/DependencyReplacementResult.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/extensions/dependency/replacement/DependencyReplacementResult.groovy
@@ -118,33 +118,6 @@ final class DependencyReplacementResult {
         );
     }
 
-
-    DependencyReplacementResult(
-            Project project,
-            Function<String, String> taskNameBuilder,
-            TaskProvider<? extends WithOutput> sourcesJarTaskProvider,
-            TaskProvider<? extends WithOutput> rawJarTaskProvider,
-            Configuration additionalDependenciesConfiguration,
-            Consumer<RepositoryReference.Builder<?,?>> referenceConfigurator,
-            Consumer<RepositoryEntry.Builder<?, ?, ?>> metadataConfigurator,
-            Consumer<Dependency> onCreateReplacedDependencyCallback,
-            Consumer<TaskProvider<? extends WithOutput>> onRepoWritingTaskRegisteredCallback,
-            Supplier<Set<TaskProvider>> additionalIdePostSyncTasks) {
-        this(
-                project,
-                taskNameBuilder,
-                sourcesJarTaskProvider,
-                rawJarTaskProvider,
-                additionalDependenciesConfiguration,
-                referenceConfigurator,
-                metadataConfigurator,
-                onCreateReplacedDependencyCallback,
-                onRepoWritingTaskRegisteredCallback,
-                additionalIdePostSyncTasks,
-                false
-        );
-    }
-
     /**
      * Gets the project inside of which a dependency replacement is being performed.
      *


### PR DESCRIPTION
I'm not sure I'll continue the simplification adventure. In the meanwhile, here are a few simplifications. Essentially, it's completely safe to create the source jar `TaskProvider` even if it won't be used later. Meaning that the distinction between IDEs and Gradle can be partially removed.