### PR TITLE
Update AccessTransformer DSL to use new Dependencies DSL to match DependencyHandler

### DIFF
--- a/common/src/main/java/net/neoforged/gradle/common/extensions/AccessTransformersExtension.java
+++ b/common/src/main/java/net/neoforged/gradle/common/extensions/AccessTransformersExtension.java
@@ -16,22 +16,19 @@ public abstract class AccessTransformersExtension extends BaseFilesWithEntriesEx
     private transient final DependencyHandler projectDependencies;
     private transient final ArtifactHandler projectArtifacts;
 
+    @SuppressWarnings("UnstableApiUsage")
     @Inject
     public AccessTransformersExtension(Project project) {
         super(project);
 
         this.projectDependencies = project.getDependencies();
         this.projectArtifacts = project.getArtifacts();
-    }
 
-    @Override
-    public Dependency consume(Object notation) {
-        return this.projectDependencies.add(CommonProjectPlugin.ACCESS_TRANSFORMER_CONFIGURATION, notation);
-    }
-
-    @Override
-    public Dependency consumeApi(Object notation) {
-        return this.projectDependencies.add(CommonProjectPlugin.ACCESS_TRANSFORMER_API_CONFIGURATION, notation);
+        // We have to add these after project evaluation because of dependency replacement making configurations non-lazy; adding them earlier would prevent further addition of dependencies
+        project.afterEvaluate(p -> {
+            p.getConfigurations().maybeCreate(CommonProjectPlugin.ACCESS_TRANSFORMER_CONFIGURATION).fromDependencyCollector(getConsume());
+            p.getConfigurations().maybeCreate(CommonProjectPlugin.ACCESS_TRANSFORMER_API_CONFIGURATION).fromDependencyCollector(getConsumeApi());
+        });
     }
 
     @Override

--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/extensions/AccessTransformers.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/extensions/AccessTransformers.groovy
@@ -5,20 +5,42 @@ import net.minecraftforge.gdi.BaseDSLElementWithFilesAndEntries
 import org.gradle.api.Action
 import org.gradle.api.artifacts.ConfigurablePublishArtifact
 import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.dsl.Dependencies
 import org.gradle.api.artifacts.dsl.DependencyCollector
 
 /**
  * Defines a DSL extension which allows for the specification of access transformers.
  */
 @CompileStatic
-interface AccessTransformers extends BaseDSLElementWithFilesAndEntries<AccessTransformers> {
-    Dependency consume(Object notation)
+interface AccessTransformers extends BaseDSLElementWithFilesAndEntries<AccessTransformers>, Dependencies {
+    /**
+     * {@return access transformers to add as dependencies}
+     */
+    DependencyCollector getConsume()
 
-    Dependency consumeApi(Object notation)
+    /**
+     * {@return access transformers to add as dependencies and also expose to consumers}
+     */
+    DependencyCollector getConsumeApi()
 
+    /**
+     * Publishes a transitive dependency on the given access transformer in the published access transformers of this component.
+     *
+     * @param dependency to expose to consumers
+     */
     void expose(Dependency dependency)
 
+    /**
+     * Publishes the provided access transformer as an artifact.
+     *
+     * @param path access transformer file to publish
+     */
     void expose(Object path)
 
+    /**
+     * Publishes the provided access transformer as an artifact and configures it with the provided action.
+     * @param path access transformer file to publish
+     * @param action configures the published artifact
+     */
     void expose(Object path, Action<ConfigurablePublishArtifact> action)
 }


### PR DESCRIPTION
Between when my PR for the AT DSL was opened and when it was merged, DependencyHandler was updated to use gradle's new `Dependencies` DSL system, which allows it to support version catalogs natively. This PR enables the same behavior for the AT DSL, which requires using `DependencyCollectors` in it -- due to NG's non-lazy-ification of every single named configuration, this means that the dependency collectors can't actually be added to the configuration until `afterEvaluate`, but this is probably fine. Similar to the changes for NG's `DependencyHandler`, this should not break buildscripts as the notation is the same, it's just expanded to make use of gradle's full typesafe dependency API.