### PR TITLE
Fix issues with a split-horizon dependency lookup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ gradleutils {
     }
 }
 
-version = "7.4.3" //gradleutils.version.toString()
+version = gradleutils.version.toString()
 
 //We hard coded the version of the gradle wrapper here.
 tasks.named('wrapper', Wrapper).configure { Wrapper wrapperTask ->

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ gradleutils {
     }
 }
 
-version = gradleutils.version.toString()
+version = "7.4.3" //gradleutils.version.toString()
 
 //We hard coded the version of the gradle wrapper here.
 tasks.named('wrapper', Wrapper).configure { Wrapper wrapperTask ->

--- a/common/src/main/java/net/neoforged/gradle/common/CommonProjectPlugin.java
+++ b/common/src/main/java/net/neoforged/gradle/common/CommonProjectPlugin.java
@@ -335,7 +335,7 @@ public class CommonProjectPlugin implements Plugin<Project> {
 
                     runImpl.getModSources().get().forEach(sourceSet -> {
                         try {
-                            final Optional<CommonRuntimeDefinition<?>> definition = TaskDependencyUtils.findRuntimeDefinition(project, sourceSet);
+                            final Optional<CommonRuntimeDefinition<?>> definition = TaskDependencyUtils.findRuntimeDefinition(sourceSet);
                             definition.ifPresent(definitionSet::add);
                         } catch (MultipleDefinitionsFoundException e) {
                             throw new RuntimeException("Failed to configure run: " + run.getName() + " there are multiple runtime definitions found for the source set: " + sourceSet.getName(), e);

--- a/common/src/main/java/net/neoforged/gradle/common/CommonProjectPlugin.java
+++ b/common/src/main/java/net/neoforged/gradle/common/CommonProjectPlugin.java
@@ -322,10 +322,6 @@ public class CommonProjectPlugin implements Plugin<Project> {
 
     @SuppressWarnings("unchecked")
     private void applyAfterEvaluate(final Project project) {
-        //Enable the dyn repo, all tools should be resolved now.
-        final Repository repository = project.getExtensions().getByType(Repository.class);
-        repository.enable();
-
         //We now eagerly get all runs and configure them.
         final NamedDomainObjectContainer<Run> runs = (NamedDomainObjectContainer<Run>) project.getExtensions().getByName(RunsConstants.Extensions.RUNS);
         runs.forEach(run -> {

--- a/common/src/main/java/net/neoforged/gradle/common/extensions/repository/IvyEntry.java
+++ b/common/src/main/java/net/neoforged/gradle/common/extensions/repository/IvyEntry.java
@@ -7,6 +7,7 @@ import net.neoforged.gradle.util.ModuleDependencyUtils;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.ExternalModuleDependency;
 
 import javax.inject.Inject;
 import java.io.Serializable;
@@ -103,7 +104,12 @@ public abstract class IvyEntry implements BaseDSLElement<Entry>, Entry, Serializ
         }
 
         private Dependency wrap(Dependency dependency) {
-            return dependency.copy();
+            if (!(dependency instanceof ExternalModuleDependency))
+                throw new IllegalArgumentException("Dependency must be an ExternalModuleDependency");
+
+            final String gav = ModuleDependencyUtils.format((ExternalModuleDependency) dependency);
+
+            return project.getDependencies().create("ng_dummy_ng." + gav);
         }
     }
 }

--- a/common/src/main/java/net/neoforged/gradle/common/extensions/repository/IvyRepository.java
+++ b/common/src/main/java/net/neoforged/gradle/common/extensions/repository/IvyRepository.java
@@ -53,6 +53,7 @@ public abstract class IvyRepository implements ConfigurableDSLElement<Repository
     public IvyRepository(Project project) {
         this.project = project;
         this.getRepositoryDirectory().convention(project.getLayout().getProjectDirectory().dir(".gradle/repositories"));
+        this.enable();
     }
 
     @Override
@@ -84,13 +85,6 @@ public abstract class IvyRepository implements ConfigurableDSLElement<Repository
 
         //Create the repo and register it.
         this.gradleRepository = this.createRepositories();
-
-        //Now we write all data to the repo.
-        //Due to the way dep replacement works, and the fact that this set is a linked hashset,
-        //we do not need to sort these. And dependency that is dynamic and uses this repo,
-        //while also depending on another dynamic dependency, will have the other dynamic dependency
-        //written first.
-        this.entries.forEach(this::write);
     }
 
     @SuppressWarnings("SameParameterValue") // Potentially this needs extension in the future.
@@ -156,13 +150,8 @@ public abstract class IvyRepository implements ConfigurableDSLElement<Repository
     }
 
     private void create(Entry entry) {
-        //We only register here.
-        //The repo is not active yet, if we were to write now, we could get into trouble
-        //when somebody tries to resolve a dependency with the same module identifier,
-        //while having a different classifier.
-        //So we write when the repo is enabled in an after evaluate, at that point all entries
-        //are registered, and we are good to go.
         this.entries.add(entry);
+        write(entry);
     }
 
     private void write(Entry entry) {

--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/extensions/dependency/replacement/DependencyReplacement.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/extensions/dependency/replacement/DependencyReplacement.groovy
@@ -49,4 +49,14 @@ interface DependencyReplacement extends BaseDSLElement<DependencyReplacement> {
      */
     @NotNull
     Dependency getSourcesJarDependency(Dependency dependency, Configuration configuration);
+
+    /**
+     * Optionally converts the given dependency back to the original dependency it replaced.
+     *
+     * @param dependency The dependency to optionally convert back.
+     * @param configuration The configuration the given dependency can be found it resides in.
+     * @return The original dependency if it can be converted back, otherwise the given dependency.
+     */
+    @NotNull
+    Dependency optionallyConvertBackToOriginal(Dependency dependency, Configuration configuration)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,4 +36,4 @@ spock_version=2.1
 spock_groovy_version=3.0
 mockito_version=4.11.0
 jimfs_version=1.2
-trainingwheels_version=1.0.45
+trainingwheels_version=1.0.46

--- a/neoform/src/main/java/net/neoforged/gradle/neoform/NeoFormProjectPlugin.java
+++ b/neoform/src/main/java/net/neoforged/gradle/neoform/NeoFormProjectPlugin.java
@@ -35,6 +35,8 @@ import javax.annotation.Nonnull;
 
 public class NeoFormProjectPlugin implements Plugin<Project> {
 
+    public static final String NEO_FORM_MAVEN = "NeoForm Maven";
+
     @Override
     public void apply(@Nonnull Project project) {
         // Needed to gain access to the common systems
@@ -49,6 +51,7 @@ public class NeoFormProjectPlugin implements Plugin<Project> {
 
         // Add Known repos
         project.getRepositories().maven(e -> {
+            e.setName(NEO_FORM_MAVEN);
             e.setUrl(UrlConstants.NEO_FORGE_MAVEN);
             e.metadataSources(MavenArtifactRepository.MetadataSources::mavenPom);
         });

--- a/userdev/src/functionalTest/groovy/net/neoforged/gradle/userdev/MultiProjectTests.groovy
+++ b/userdev/src/functionalTest/groovy/net/neoforged/gradle/userdev/MultiProjectTests.groovy
@@ -1,0 +1,104 @@
+package net.neoforged.gradle.userdev
+
+import net.neoforged.trainingwheels.gradle.functional.BuilderBasedTestSpecification
+import org.gradle.testkit.runner.TaskOutcome
+
+class MultiProjectTests extends BuilderBasedTestSpecification {
+
+    @Override
+    protected void configurePluginUnderTest() {
+        pluginUnderTest = "net.neoforged.gradle.userdev";
+        injectIntoAllProject = true;
+    }
+
+    @Override
+    protected File getTestTempDirectory() {
+        return new File("build/functionalTest")
+    }
+
+    def "multiple projects with neoforge dependencies should be able to run the game"() {
+        given:
+        def rootProject = create("multi_neoforge_root", {
+            it.build("""
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(21)
+                }
+            }
+            """)
+            it.withToolchains()
+        })
+
+        def apiProject = create(rootProject, "api", {
+            it.build("""
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(21)
+                }
+            }
+            
+            dependencies {
+                implementation 'net.neoforged:neoforge:+'
+            }
+            """)
+            it.file("src/main/java/net/neoforged/gradle/apitest/FunctionalTests.java", """
+                package net.neoforged.gradle.apitest;
+                
+                import net.minecraft.client.Minecraft;
+                
+                public class FunctionalTests {
+                    public static void main(String[] args) {
+                        System.out.println(Minecraft.getInstance().getClass().toString());
+                    }
+                }
+            """)
+            it.withToolchains()
+        })
+
+        def mainProject = create(rootProject,"main", {
+            it.build("""
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(21)
+                }
+            }
+            
+            dependencies {
+                implementation 'net.neoforged:neoforge:+'
+                implementation project(':api')
+            }
+            
+            runs {
+                client {
+                    modSource project(':api').sourceSets.main
+                }
+            }
+            """)
+            it.file("src/main/java/net/neoforged/gradle/main/ApiTests.java", """
+                package net.neoforged.gradle.main;
+                
+                import net.minecraft.client.Minecraft;
+                import net.neoforged.gradle.apitest.FunctionalTests;
+                
+                public class ApiTests {
+                    public static void main(String[] args) {
+                        System.out.println(Minecraft.getInstance().getClass().toString());
+                        FunctionalTests.main(args);
+                    }
+                }
+            """)
+            it.withToolchains()
+        })
+
+        when:
+        def run = rootProject.run {
+            it.tasks(':main:runData')
+            //We are expecting this test to fail, since there is a mod without any files included so it is fine.
+            it.shouldFail()
+        }
+
+        then:
+        run.task(':main:writeMinecraftClasspathData').outcome == TaskOutcome.SUCCESS
+        run.output.contains("Error during pre-loading phase: ERROR: File null is not a valid mod file") //Validate that we are failing because of the missing mod file, and not something else.
+    }
+}

--- a/userdev/src/functionalTest/groovy/net/neoforged/gradle/userdev/UserDevPluginTests.groovy
+++ b/userdev/src/functionalTest/groovy/net/neoforged/gradle/userdev/UserDevPluginTests.groovy
@@ -40,24 +40,6 @@ class UserDevPluginTests extends SimpleTestSpecification {
         result.output.contains('net.neoforged.gradle.common.CommonPlugin')
     }
 
-    def "applying userdev plugin applies forge extension"() {
-        given:
-        settingsFile << "rootProject.name = 'test-project'"
-        buildFile << """
-            plugins {
-                id 'net.neoforged.gradle.userdev'
-            }
-            
-            println project.userDev.class.toString()
-        """
-
-        when:
-        def result = gradleRunner().build()
-
-        then:
-        result.output.contains('UserDevExtension')
-    }
-
     def "applying userdev plugin applies userDev runtime extension"() {
         given:
         settingsFile << "rootProject.name = 'test-project'"

--- a/userdev/src/main/java/net/neoforged/gradle/userdev/UserDevProjectPlugin.java
+++ b/userdev/src/main/java/net/neoforged/gradle/userdev/UserDevProjectPlugin.java
@@ -4,10 +4,15 @@ import net.neoforged.gradle.common.extensions.DefaultJarJarFeature;
 import net.neoforged.gradle.common.extensions.JarJarExtension;
 import net.neoforged.gradle.dsl.common.extensions.JarJar;
 import net.neoforged.gradle.neoform.NeoFormPlugin;
+import net.neoforged.gradle.neoform.NeoFormProjectPlugin;
 import net.neoforged.gradle.userdev.dependency.UserDevDependencyManager;
 import net.neoforged.gradle.userdev.runtime.extension.UserDevRuntimeExtension;
+import net.neoforged.gradle.util.UrlConstants;
+import org.gradle.api.NamedDomainObjectProvider;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.artifacts.repositories.ArtifactRepository;
+import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
 
 public class UserDevProjectPlugin implements Plugin<Project> {
     public static final String JAR_JAR_TASK_NAME = DefaultJarJarFeature.JAR_JAR_TASK_NAME;


### PR DESCRIPTION
This fixes an issue where due to recent changes gradle is having problems discovering where the module data itself is residing.