### PR TITLE
[Fix] Update JST and add back support for MultiSourceSet setups

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,11 +126,12 @@ This can be useful to run NeoGradle on lower-end machines, at the cost of slower
 The settings used by Neogradle for recompiling the decompiled Minecraft source code can be customized
 using [Gradle properties](https://docs.gradle.org/current/userguide/project_properties.html).
 
-| Property                                    | Description                                                                                                                          |
-|---------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
-| `neogradle.subsystems.recompiler.maxMemory` | How much heap memory is given to the decompiler. Can be specified either in gigabyte (`4g`) or megabyte (`4096m`). Defaults to `1g`. |
-| `neogradle.subsystems.recompiler.jvmArgs`   | Pass arbitrary JVM arguments to the forked Gradle process that runs the compiler. I.e. `-XX:+HeapDumpOnOutOfMemoryError`             |
-| `neogradle.subsystems.recompiler.args`      | Pass additional command line arguments to the Java compiler.                                                                         |
+| Property                                     | Description                                                                                                                          |
+|----------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
+| `neogradle.subsystems.recompiler.maxMemory`  | How much heap memory is given to the decompiler. Can be specified either in gigabyte (`4g`) or megabyte (`4096m`). Defaults to `1g`. |
+| `neogradle.subsystems.recompiler.jvmArgs`    | Pass arbitrary JVM arguments to the forked Gradle process that runs the compiler. I.e. `-XX:+HeapDumpOnOutOfMemoryError`             |
+| `neogradle.subsystems.recompiler.args`       | Pass additional command line arguments to the Java compiler.                                                                         |
+| `neogradle.subsystems.recompiler.shouldFork` | Indicates whether or not a process fork should be used for the recompiler. (Default is true).                                        |
 
 ## Run specific dependency management
 This implements run specific dependency management for the classpath of a run.
@@ -238,13 +239,11 @@ Per SourceSet the following configurations are added, where XXX is the SourceSet
 
 Per Run the following configurations are added:
 - XXXRun
-- XXXMod
 > [!NOTE]
 > For this to work, your Runs need to be defined before your dependency block.
 
 Globally the following configurations are added:
 - runs
-- mods
 
 #### LocalRuntime (Per SourceSet)
 This configuration is used to add dependencies to your local projects runtime only, without exposing them to the runtime of other projects.
@@ -257,14 +256,8 @@ Requires source set conventions to be enabled
 #### Run (Per Run)
 This configuration is used to add dependencies to the runtime of a specific run only, without exposing them to the runtime of other runs.
 
-#### Mod (Per Run)
-This configuration is used to add dependencies (and their dependencies), straight into the mods folder, without exposing them to the runtime of the run itself, or other runs.
-
 #### run (Global)
 This configuration is used to add dependencies to the runtime of all runs.
-
-#### mods (Global)
-This configuration is used to add dependencies (and their dependencies), straight into the mods folder of all runs, without exposing them to the runtime of the runs.
 
 ### Sourceset Management
 To disable the sourceset management, you can set the following property in your gradle.properties:

--- a/README.md
+++ b/README.md
@@ -89,11 +89,6 @@ subsystems {
     // The built-in default value can also be overriden using the Gradle property neogradle.subsystems.parchment.parchmentArtifact
     // parchmentArtifact = "org.parchmentmc.data:parchment-$minecraftVersion:$mappingsVersion:checked@zip"
     
-    // Overrides the full Maven coordinate of the tool used to apply the Parchment mappings
-    // See https://github.com/neoforged/JavaSourceTransformer
-    // The built-in default value can also be overriden using the Gradle property neogradle.subsystems.parchment.toolArtifact
-    // toolArtifact = "net.neoforged.jst:jst-cli-bundle:1.0.30"
-    
     // Set this to false if you don't want the https://maven.parchmentmc.org/ repository to be added automatically when
     // applying Parchment mappings is enabled
     // The built-in default value can also be overriden using the Gradle property neogradle.subsystems.parchment.addRepository
@@ -354,4 +349,13 @@ By default, a run is created for each type of run.
 If you want to disable this, you can set the following property in your gradle.properties:
 ```properties
 neogradle.subsystems.conventions.runs.create-default-run-per-type=false
+```
+
+## Tool overrides
+To configure tools used by different subsystems of NG, the subsystems dsl and properties can be used to configure the following tools:
+### JST
+This tool is used by the parchment subsystem to apply its names and javadoc, as well as by the source access transformer system to apply its transformations.
+The following properties can be used to configure the JST tool:
+```properties
+neogradle.subsystems.tools.jst=<artifact coordinate for jst cli tool>
 ```

--- a/common/src/main/java/net/neoforged/gradle/common/extensions/subsystems/SubsystemsExtension.java
+++ b/common/src/main/java/net/neoforged/gradle/common/extensions/subsystems/SubsystemsExtension.java
@@ -32,6 +32,14 @@ public abstract class SubsystemsExtension extends WithPropertyLookup implements 
         configureDecompilerDefaults();
         configureRecompilerDefaults();
         configureParchmentDefaults();
+        configureToolsDefaults();
+    }
+
+    private void configureToolsDefaults() {
+        Tools tools = getTools();
+        tools.getJST().convention(
+                getStringProperty("tools.jst").orElse(JST_TOOL_ARTIFACT)
+        );
     }
 
     private void configureDecompilerDefaults() {
@@ -77,9 +85,6 @@ public abstract class SubsystemsExtension extends WithPropertyLookup implements 
         );
         parchment.getMappingsVersion().convention(
                 getStringProperty("parchment.mappingsVersion")
-        );
-        parchment.getToolArtifact().convention(
-                getStringProperty("parchment.toolArtifact").orElse(JST_TOOL_ARTIFACT)
         );
         parchment.getAddRepository().convention(
                 getBooleanProperty("parchment.addRepository").orElse(true)

--- a/common/src/main/java/net/neoforged/gradle/common/extensions/subsystems/SubsystemsExtension.java
+++ b/common/src/main/java/net/neoforged/gradle/common/extensions/subsystems/SubsystemsExtension.java
@@ -53,6 +53,7 @@ public abstract class SubsystemsExtension extends WithPropertyLookup implements 
         recompiler.getArgs().convention(getSpaceSeparatedListProperty("recompiler.args").orElse(Collections.emptyList()));
         recompiler.getJvmArgs().convention(getSpaceSeparatedListProperty("recompiler.jvmArgs").orElse(Collections.emptyList()));
         recompiler.getMaxMemory().convention(getStringProperty("recompiler.maxMemory").orElse(DEFAULT_RECOMPILER_MAX_MEMORY));
+        recompiler.getShouldFork().convention(getBooleanProperty("recompiler.shouldFork").orElse(true));
     }
 
     private void configureParchmentDefaults() {

--- a/common/src/main/java/net/neoforged/gradle/common/runtime/tasks/SourceAccessTransformer.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runtime/tasks/SourceAccessTransformer.java
@@ -2,6 +2,7 @@ package net.neoforged.gradle.common.runtime.tasks;
 
 import com.google.common.collect.Lists;
 import net.neoforged.gradle.common.util.ToolUtilities;
+import net.neoforged.gradle.dsl.common.extensions.subsystems.Subsystems;
 import net.neoforged.gradle.dsl.common.util.Constants;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.RegularFileProperty;
@@ -25,7 +26,7 @@ public abstract class SourceAccessTransformer extends Execute {
 
         setDescription("Runs the access transformer on the decompiled sources.");
 
-        getExecutingJar().set(ToolUtilities.resolveTool(getProject(), Constants.JST_TOOL_ARTIFACT));
+        getExecutingJar().set(ToolUtilities.resolveTool(getProject(), getProject().getExtensions().getByType(Subsystems.class).getTools().getJST().get()));
         getRuntimeProgramArguments().convention(
                 getInputFile().map(inputFile -> {
                             final List<String> args = Lists.newArrayList();

--- a/common/src/main/java/net/neoforged/gradle/common/runtime/tasks/SourceAccessTransformer.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runtime/tasks/SourceAccessTransformer.java
@@ -5,6 +5,7 @@ import net.neoforged.gradle.common.util.ToolUtilities;
 import net.neoforged.gradle.dsl.common.util.Constants;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.InputFiles;
@@ -46,8 +47,7 @@ public abstract class SourceAccessTransformer extends Execute {
                 )
         );
 
-        getJavaVersion().set(JavaLanguageVersion.of(17));
-
+        getJavaVersion().convention(getProject().getExtensions().getByType(JavaPluginExtension.class).getToolchain().getLanguageVersion());
         getTransformers().finalizeValueOnRead();
     }
 

--- a/common/src/main/java/net/neoforged/gradle/common/util/VersionJson.java
+++ b/common/src/main/java/net/neoforged/gradle/common/util/VersionJson.java
@@ -68,6 +68,7 @@ public class VersionJson implements Serializable {
     @Nullable
     private Map<String, Download> downloads;
     private Library[] libraries;
+    private JavaVersion javaVersion;
 
     private List<LibraryDownload> _natives = null;
     private List<Library> _libraries = null;
@@ -136,6 +137,10 @@ public class VersionJson implements Serializable {
         return downloads;
     }
 
+    public JavaVersion getJavaVersion() {
+        return javaVersion;
+    }
+
     public List<Library> getLibraries() {
         if (this._libraries == null) {
             this._libraries = new ArrayList<>();
@@ -155,6 +160,19 @@ public class VersionJson implements Serializable {
 
     public String getMainClass() {
         return mainClass;
+    }
+
+    public static class JavaVersion implements Serializable {
+        private String component;
+        private String majorVersion;
+
+        public String getComponent() {
+            return component;
+        }
+
+        public String getMajorVersion() {
+            return majorVersion;
+        }
     }
 
     public static class Arguments implements Serializable {

--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/extensions/subsystems/Parchment.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/extensions/subsystems/Parchment.groovy
@@ -41,14 +41,6 @@ interface Parchment extends ConfigurableDSLElement<Parchment> {
     Property<String> getMappingsVersion();
 
     /**
-     * Artifact coordinates for the tool used to apply the mappings. Overriding this is an advanced use case.
-     */
-    @Input
-    @Optional
-    @DSLProperty
-    Property<String> getToolArtifact();
-
-    /**
      * If enabled (the default), the parchment repository will automatically be added to the project,
      * if {@link #getEnabled()} is true.
      */

--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/extensions/subsystems/Recompiler.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/extensions/subsystems/Recompiler.groovy
@@ -40,4 +40,12 @@ interface Recompiler extends ConfigurableDSLElement<Recompiler> {
     @DSLProperty
     ListProperty<String> getArgs();
 
+    /**
+     * Indicates whether the compiler should fork the process.
+     */
+    @Input
+    @Optional
+    @DSLProperty
+    Property<Boolean> getShouldFork();
+
 }

--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/extensions/subsystems/Subsystems.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/extensions/subsystems/Subsystems.groovy
@@ -38,4 +38,11 @@ interface Subsystems extends BaseDSLElement<Subsystems> {
     @Nested
     @DSLProperty
     Conventions getConventions();
+
+    /**
+     * @return settings for the tools subsystem
+     */
+    @Nested
+    @DSLProperty
+    Tools getTools();
 }

--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/extensions/subsystems/Tools.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/extensions/subsystems/Tools.groovy
@@ -1,0 +1,26 @@
+package net.neoforged.gradle.dsl.common.extensions.subsystems
+
+import groovy.transform.CompileStatic
+import net.minecraftforge.gdi.ConfigurableDSLElement
+import net.minecraftforge.gdi.annotations.DSLProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+
+/**
+ * Allows configuration of Parchment mappings for userdev.
+ */
+@CompileStatic
+interface Tools extends ConfigurableDSLElement<Parchment> {
+
+
+    /**
+     * Artifact coordinates for JST.
+     * Used by the parchment subsystem to generate mappings, and by the AT subsystem to apply access transformers to source.
+     */
+    @Input
+    @Optional
+    @DSLProperty
+    Property<String> getJST();
+
+}

--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/util/ConfigurationUtils.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/util/ConfigurationUtils.groovy
@@ -41,10 +41,37 @@ class ConfigurationUtils {
 
             configuration.setCanBeConsumed(false)
             configuration.setCanBeResolved(true)
+
+            final DependencyReplacement dependencyReplacement = project.getExtensions().getByType(DependencyReplacement.class)
+            dependencyReplacement.handleConfiguration(configuration)
         }
 
-        final DependencyReplacement dependencyReplacement = project.getExtensions().getByType(DependencyReplacement.class)
-        dependencyReplacement.handleConfiguration(configuration)
+        return configuration
+    }
+
+    /**
+     * Creates a configuration that can be resolved, but not consumed.
+     *
+     * @param project The project to create the configuration for
+     * @param context The context of the configuration
+     * @param processor The processor to apply to the configuration
+     * @return The detached configuration
+     */
+    static Configuration temporaryConfiguration(final Project project, final String context, final Action<Configuration> processor) {
+        final String name = "neoGradleInternal${context.capitalize()}"
+        final boolean exists = project.getConfigurations().getNames().contains(name)
+
+        final Configuration configuration = project.getConfigurations().maybeCreate("neoGradleInternal${context.capitalize()}")
+
+        if (!exists) {
+            processor.execute(configuration)
+
+            configuration.setCanBeConsumed(false)
+            configuration.setCanBeResolved(true)
+
+            final DependencyReplacement dependencyReplacement = project.getExtensions().getByType(DependencyReplacement.class)
+            dependencyReplacement.handleConfiguration(configuration)
+        }
 
         return configuration
     }

--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/util/Constants.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/util/Constants.groovy
@@ -27,7 +27,7 @@ class Constants {
     public static final String DEFAULT_PARCHMENT_GROUP = "org.parchmentmc.data"
     public static final String DEFAULT_PARCHMENT_ARTIFACT_PREFIX = "parchment-"
     public static final String DEFAULT_PARCHMENT_MAVEN_URL = "https://maven.parchmentmc.org/"
-    public static final String JST_TOOL_ARTIFACT = "net.neoforged.jst:jst-cli-bundle:1.0.35"
+    public static final String JST_TOOL_ARTIFACT = "net.neoforged.jst:jst-cli-bundle:1.0.36"
 
     public static final String DEFAULT_RECOMPILER_MAX_MEMORY = "1g"
 

--- a/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/extensions/NeoFormRuntimeExtension.java
+++ b/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/extensions/NeoFormRuntimeExtension.java
@@ -50,6 +50,7 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.compile.AbstractCompile;
 import org.gradle.api.tasks.compile.ForkOptions;
+import org.gradle.jvm.toolchain.JavaLanguageVersion;
 import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
@@ -471,6 +472,8 @@ public abstract class NeoFormRuntimeExtension extends CommonRuntimeExtension<Neo
                     forkOptions.setMemoryMaximumSize(maxMemory);
                     forkOptions.setJvmArgs(settings.getJvmArgs().get());
                     task.getOptions().getCompilerArgumentProviders().add(settings.getArgs()::get);
+
+                    task.getJavaVersion().set(JavaLanguageVersion.of(definition.getVersionJson().getJavaVersion().getMajorVersion()));
 
                     for (Task dependency : recompileDependencies.getBuildDependencies().getDependencies(task)) {
                         task.dependsOn(dependency);

--- a/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/extensions/NeoFormRuntimeExtension.java
+++ b/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/extensions/NeoFormRuntimeExtension.java
@@ -13,11 +13,7 @@ import net.neoforged.gradle.dsl.common.extensions.ConfigurationData;
 import net.neoforged.gradle.dsl.common.extensions.Mappings;
 import net.neoforged.gradle.dsl.common.extensions.Minecraft;
 import net.neoforged.gradle.dsl.common.extensions.MinecraftArtifactCache;
-import net.neoforged.gradle.dsl.common.extensions.subsystems.Decompiler;
-import net.neoforged.gradle.dsl.common.extensions.subsystems.DecompilerLogLevel;
-import net.neoforged.gradle.dsl.common.extensions.subsystems.Parchment;
-import net.neoforged.gradle.dsl.common.extensions.subsystems.Recompiler;
-import net.neoforged.gradle.dsl.common.extensions.subsystems.Subsystems;
+import net.neoforged.gradle.dsl.common.extensions.subsystems.*;
 import net.neoforged.gradle.dsl.common.runtime.naming.TaskBuildingContext;
 import net.neoforged.gradle.dsl.common.runtime.tasks.Runtime;
 import net.neoforged.gradle.dsl.common.runtime.tasks.RuntimeArguments;
@@ -510,6 +506,7 @@ public abstract class NeoFormRuntimeExtension extends CommonRuntimeExtension<Neo
                                                              Provider<RegularFile> listLibrariesOutput) {
         Project project = spec.getProject();
         Parchment parchment = project.getExtensions().getByType(Subsystems.class).getParchment();
+        Tools tools = project.getExtensions().getByType(Subsystems.class).getTools();
         if (!parchment.getEnabled().get()) {
             return recompileInput;
         }
@@ -517,7 +514,7 @@ public abstract class NeoFormRuntimeExtension extends CommonRuntimeExtension<Neo
         TaskProvider<? extends Runtime> applyParchmentTask = project.getTasks().register(CommonRuntimeUtils.buildTaskName(spec, "applyParchment"), Execute.class, task -> {
             // Provide the mappings via artifact
             File mappingFile = ToolUtilities.resolveTool(project, parchment.getParchmentArtifact().get());
-            File toolExecutable = ToolUtilities.resolveTool(project, parchment.getToolArtifact().get());
+            File toolExecutable = ToolUtilities.resolveTool(project, tools.getJST().get());
 
             task.getInputs().file(mappingFile);
             task.getInputs().file(recompileInput);

--- a/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/extensions/NeoFormRuntimeExtension.java
+++ b/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/extensions/NeoFormRuntimeExtension.java
@@ -468,6 +468,7 @@ public abstract class NeoFormRuntimeExtension extends CommonRuntimeExtension<Neo
                     // Consider user-settings
                     Recompiler settings = spec.getProject().getExtensions().getByType(Subsystems.class).getRecompiler();
                     String maxMemory = settings.getMaxMemory().get();
+                    task.getOptions().setFork(settings.getShouldFork().get());
                     ForkOptions forkOptions = task.getOptions().getForkOptions();
                     forkOptions.setMemoryMaximumSize(maxMemory);
                     forkOptions.setJvmArgs(settings.getJvmArgs().get());

--- a/userdev/src/functionalTest/groovy/net/neoforged/gradle/userdev/FunctionalTests.groovy
+++ b/userdev/src/functionalTest/groovy/net/neoforged/gradle/userdev/FunctionalTests.groovy
@@ -378,4 +378,64 @@ class FunctionalTests extends BuilderBasedTestSpecification {
         initialRun.task(":build").outcome == TaskOutcome.SUCCESS
     }
 
+
+
+    def "a mod with userdev can have multiple sourcesets with neoforge"() {
+        given:
+        def project = create("gradle_multi_sourceset", {
+            it.build("""
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(21)
+                }
+            }
+            
+            sourceSets {
+                content {
+                    java {
+                        srcDir 'src/content/java'
+                    }
+                }
+            }
+            
+            dependencies {
+                implementation 'net.neoforged:neoforge:+'
+                contentImplementation 'net.neoforged:neoforge:+'
+            }
+            """)
+            it.file("src/main/java/net/neoforged/gradle/userdev/FunctionalTests.java", """
+                package net.neoforged.gradle.userdev;
+                
+                import net.minecraft.client.Minecraft;
+                
+                public class FunctionalTests {
+                    public static void main(String[] args) {
+                        System.out.println(Minecraft.getInstance().getClass().toString());
+                    }
+                }
+            """)
+            it.file("src/content/java/net/neoforged/gradle/userdev/ContentTests.java", """
+                package net.neoforged.gradle.userdev;
+                
+                import net.minecraft.client.Minecraft;
+                
+                public class ContentTests {
+                    public static void main(String[] args) {
+                        System.out.println(Minecraft.getInstance().getClass().toString());
+                    }
+                }
+            """)
+            it.withToolchains()
+        })
+
+        when:
+        def run = project.run {
+            it.tasks('clean', 'build')
+            it.stacktrace()
+        }
+
+        then:
+        run.task(':clean').outcome == TaskOutcome.SUCCESS
+        run.task(':build').outcome == TaskOutcome.SUCCESS
+    }
 }

--- a/userdev/src/main/java/net/neoforged/gradle/userdev/dependency/UserDevDependencyManager.java
+++ b/userdev/src/main/java/net/neoforged/gradle/userdev/dependency/UserDevDependencyManager.java
@@ -39,10 +39,13 @@ public final class UserDevDependencyManager {
             
             final Configuration additionalDependenciesConfiguration = ConfigurationUtils.temporaryConfiguration(
                     project,
-                    "NeoForgeUserDevAdditionalReplacementDependenciesFor" + runtimeDefinition.getSpecification().getIdentifier()
+                    "NeoForgeUserDevAdditionalReplacementDependenciesFor" + runtimeDefinition.getSpecification().getIdentifier(),
+                    configuration -> {
+                        configuration.setDescription("Additional dependencies for the NeoForge UserDev replacement for " + runtimeDefinition.getSpecification().getIdentifier());
+                        configuration.extendsFrom(runtimeDefinition.getNeoFormRuntimeDefinition().getMinecraftDependenciesConfiguration());
+                        configuration.extendsFrom(runtimeDefinition.getAdditionalUserDevDependencies());
+                    }
             );
-            additionalDependenciesConfiguration.extendsFrom(runtimeDefinition.getNeoFormRuntimeDefinition().getMinecraftDependenciesConfiguration());
-            additionalDependenciesConfiguration.extendsFrom(runtimeDefinition.getAdditionalUserDevDependencies());
             
             return Optional.of(
                     new UserDevReplacementResult(

--- a/vanilla/src/main/java/net/neoforged/gradle/vanilla/runtime/steps/ParchmentStep.java
+++ b/vanilla/src/main/java/net/neoforged/gradle/vanilla/runtime/steps/ParchmentStep.java
@@ -6,6 +6,7 @@ import net.neoforged.gradle.common.runtime.tasks.NoopRuntime;
 import net.neoforged.gradle.common.util.ToolUtilities;
 import net.neoforged.gradle.dsl.common.extensions.subsystems.Parchment;
 import net.neoforged.gradle.dsl.common.extensions.subsystems.Subsystems;
+import net.neoforged.gradle.dsl.common.extensions.subsystems.Tools;
 import net.neoforged.gradle.dsl.common.runtime.tasks.Runtime;
 import net.neoforged.gradle.dsl.common.tasks.WithOutput;
 import net.neoforged.gradle.dsl.common.util.CommonRuntimeUtils;
@@ -44,6 +45,8 @@ public class ParchmentStep implements IStep {
                                                                        Provider<RegularFile> listLibrariesOutput) {
         Project project = spec.getProject();
         Parchment parchment = project.getExtensions().getByType(Subsystems.class).getParchment();
+        Tools tools = project.getExtensions().getByType(Subsystems.class).getTools();
+
         if (!parchment.getEnabled().get()) {
             return project.getTasks().register(CommonRuntimeUtils.buildTaskName(spec, "applyParchmentNoop"), NoopRuntime.class, task -> {
                 task.getInput().set(inputProvidingTask.flatMap(WithOutput::getOutput));
@@ -53,7 +56,7 @@ public class ParchmentStep implements IStep {
         return project.getTasks().register(CommonRuntimeUtils.buildTaskName(spec, "applyParchment"), Execute.class, task -> {
             // Provide the mappings via artifact
             File mappingFile = ToolUtilities.resolveTool(project, parchment.getParchmentArtifact().get());
-            File toolExecutable = ToolUtilities.resolveTool(project, parchment.getToolArtifact().get());
+            File toolExecutable = ToolUtilities.resolveTool(project, tools.getJST().get());
 
             task.getInputs().file(mappingFile);
             task.getInputs().file(inputProvidingTask.flatMap(WithOutput::getOutput));


### PR DESCRIPTION
- Ensure that multiple sourcesets in the same project are supported
- Recompile the game with the required java version, regardless of what the user configures!
- SATs now default to the user selected runtime, specs don't have a version json so we can not pull it from there.
- Add the ability to disable the process fork for the recompiler.