### PR TITLE
[Hotfix]: Fix the lookup of delegated runs on none neogradle projects

### DIFF
--- a/common/src/main/java/net/neoforged/gradle/common/util/TaskDependencyUtils.java
+++ b/common/src/main/java/net/neoforged/gradle/common/util/TaskDependencyUtils.java
@@ -141,9 +141,12 @@ public final class TaskDependencyUtils {
         return context.getRuntimes();
     }
 
-    @SuppressWarnings("SuspiciousMethodCalls")
     private static List<CommonRuntimeDefinition<?>> unwrapDelegation(final Project project, final Collection<? extends CommonRuntimeDefinition<?>> input) {
         final List<CommonRuntimeDefinition<?>> output = new LinkedList<>();
+
+        if (project.getExtensions().findByType(RuntimesExtension.class) == null) {
+            return input.stream().distinct().collect(Collectors.toList());
+        }
 
         project.getExtensions().getByType(RuntimesExtension.class)
                 .getAllDefinitions()

--- a/userdev/src/functionalTest/groovy/net/neoforged/gradle/userdev/MultiProjectTests.groovy
+++ b/userdev/src/functionalTest/groovy/net/neoforged/gradle/userdev/MultiProjectTests.groovy
@@ -7,13 +7,8 @@ class MultiProjectTests extends BuilderBasedTestSpecification {
 
     @Override
     protected void configurePluginUnderTest() {
-        pluginUnderTest = "net.neoforged.gradle.userdev";
-        injectIntoAllProject = true;
-    }
-
-    @Override
-    protected File getTestTempDirectory() {
-        return new File("build/functionalTest")
+        pluginUnderTest = "net.neoforged.gradle.userdev"
+        injectIntoRootProject = true
     }
 
     def "multiple projects with neoforge dependencies should be able to run the game"() {
@@ -53,6 +48,7 @@ class MultiProjectTests extends BuilderBasedTestSpecification {
                 }
             """)
             it.withToolchains()
+            it.plugin(this.pluginUnderTest)
         })
 
         def mainProject = create(rootProject,"main", {
@@ -88,6 +84,92 @@ class MultiProjectTests extends BuilderBasedTestSpecification {
                 }
             """)
             it.withToolchains()
+            it.plugin(this.pluginUnderTest)
+        })
+
+        when:
+        def run = rootProject.run {
+            it.tasks(':main:runData')
+            //We are expecting this test to fail, since there is a mod without any files included so it is fine.
+            it.shouldFail()
+        }
+
+        then:
+        run.task(':main:writeMinecraftClasspathData').outcome == TaskOutcome.SUCCESS
+        run.output.contains("Error during pre-loading phase: ERROR: File null is not a valid mod file") //Validate that we are failing because of the missing mod file, and not something else.
+    }
+
+    def "multiple projects where one is not neogradle with neoforge dependencies should be able to run the game"() {
+        given:
+        def rootProject = create("multi_neoforge_root_none_ng", {
+            it.build("""
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(21)
+                }
+            }
+            """)
+            it.withToolchains()
+        })
+
+        def apiProject = create(rootProject, "api", {
+            it.build("""
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(21)
+                }
+            }
+            
+            dependencies {
+            }
+            """)
+            it.file("src/main/java/net/neoforged/gradle/apitest/FunctionalTests.java", """
+                package net.neoforged.gradle.apitest;
+                
+                public class FunctionalTests {
+                    public static void main(String[] args) {
+                        System.out.println("Hello World");
+                    }
+                }
+            """)
+            it.withToolchains()
+            it.plugin("java-library")
+        })
+
+        def mainProject = create(rootProject,"main", {
+            it.build("""
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(21)
+                }
+            }
+            
+            dependencies {
+                implementation 'net.neoforged:neoforge:+'
+                implementation project(':api')
+            }
+            
+            runs {
+                client {
+                    modSource project(':api').sourceSets.main
+                }
+            }
+            """)
+            it.file("src/main/java/net/neoforged/gradle/main/ApiTests.java", """
+                package net.neoforged.gradle.main;
+                
+                import net.minecraft.client.Minecraft;
+                import net.neoforged.gradle.apitest.FunctionalTests;
+                
+                public class ApiTests {
+                    public static void main(String[] args) {
+                        System.out.println(Minecraft.getInstance().getClass().toString());
+                        FunctionalTests.main(args);
+                    }
+                }
+            """)
+            it.withToolchains()
+            it.plugin(this.pluginUnderTest)
         })
 
         when:


### PR DESCRIPTION
This fixes a bug where we tried to lookup delegations (which does not exist) on projects which did not have the neogradle plugin applied.