### PR TITLE
Use unique contexts for installer library lookup

### DIFF
--- a/dsl/platform/src/main/groovy/net/neoforged/gradle/dsl/platform/model/InstallerProfile.groovy
+++ b/dsl/platform/src/main/groovy/net/neoforged/gradle/dsl/platform/model/InstallerProfile.groovy
@@ -195,7 +195,7 @@ abstract class InstallerProfile implements ConfigurableDSLElement<InstallerProfi
                 final Dependency[] dependencies = dependencyCoordinates.stream().map { coord -> project.getDependencies().create(coord) }.toArray(Dependency[]::new)
                 final Configuration configuration = ConfigurationUtils.temporaryConfiguration(
                         project,
-                        "InstallerProfileLibraryLookup",
+                        "InstallerProfileLibraryLookup" + ModuleDependencyUtils.toConfigurationName(tool),
                         dependencies)
 
                 final LibraryCollector collector = new LibraryCollector(project.getObjects(), project.getRepositories()


### PR DESCRIPTION
This PR fixes a current issue with the generation of the legacy installer profile that causes the tools used in the processor steps to not be included in the `libraries` section, causing the tools to not be downloaded.

The fix is to change the context used for calling `temporaryConfiguration` to be unique for each given tool, rather than using a constant context.

The use of a constant context meant that each call to `temporaryConfiguration` resulted in the same configuration being returned.  As `temporaryConfiguration` only adds the requested libraries on the first use of the configuration (as it checks if the configuration is first empty before adding the requested dependencies), any subsequent invocation with the same context, even with _different_ dependencies as arguments, would just return the configuration from the first invocation unchanged.