### PR TITLE
[Feature]: Add support for DevLogin

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,3 +359,57 @@ The following properties can be used to configure the JST tool:
 ```properties
 neogradle.subsystems.tools.jst=<artifact coordinate for jst cli tool>
 ```
+### DevLogin
+This tool is used by the runs subsystem to enable logged in plays on all client runs.
+The following properties can be used to configure the DevLogin tool:
+```properties
+neogradle.subsystems.tools.devLogin=<artifact coordinate for devlogin cli tool>
+```
+
+## DevLogin
+The DevLogin tool is a tool that allows you to log in to a Minecraft account without having to use the Minecraft launcher, during development.
+This tool is used by the runs subsystem to enable logged in plays on all client runs.
+The tool can be configured using the following properties:
+```properties
+neogradle.subsystems.devLogin.enabled=<true/false>
+```
+By default, the subsystem is enabled, and it will ask you to log in when you run a client run.
+If you want to disable this, you can set the property to false, and then you will not be asked to log in, but use a random none signed in dev account.
+
+Additionally, you can configure whether to add the relevant repositories to your buildscript:
+```properties
+neogradle.subsystems.devLogin.addRepositories=<true/false>
+``` 
+By default, the repositories are added, but if you want to disable this, you can set the property to false.
+By doing so you are responsible for adding a maven repository that provides the dev login CLI artifact.
+
+## Centralized Cache
+NeoGradle has a centralized cache that can be used to store the decompiled Minecraft sources, the recompiled Minecraft sources, and other task outputs of complex tasks.
+The cache is enabled by default, and can be disabled by setting the following property in your gradle.properties:
+```properties
+net.neoforged.gradle.caching.enabled=false
+```
+
+You can clean the artifacts that are stored in the cache by running the following command:
+```shell
+./gradlew cleanCache
+```
+
+This command is also automatically ran, when you run the clean task.
+The command will check if the stored artifact count is higher than the configured threshold, and if so remove the oldest artifacts until the count is below the threshold.
+The count is configured by the following property in your gradle.properties:
+```properties
+net.neoforged.gradle.caching.maxCacheSize=<number>
+```
+
+### Debugging
+There are two properties you can tweak to get more information about the cache:
+```properties
+net.neoforged.gradle.caching.logCacheHits=<true/false>
+```
+and
+```properties
+net.neoforged.gradle.caching.debug=<true/false>
+```
+The first property will log when a cache hit occurs, and the second property will log more information about the cache in general, including how hashes are calculated.
+If you are experiencing issues with the cache, you can enable these properties to get more information about what is happening.

--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ runs {
     }
 }
 ```
-This will disable the dev login tool for this run. By default, the dev login tool is enabled for all client runs.
+This will disable the dev login tool for this run. By default, the dev login tool is disable, and can only be enabled for client runs.
 
 > [!WARNING]
 > If you enable the dev login tool for a none client run, you will get an error message.

--- a/README.md
+++ b/README.md
@@ -383,6 +383,20 @@ neogradle.subsystems.devLogin.addRepositories=<true/false>
 By default, the repositories are added, but if you want to disable this, you can set the property to false.
 By doing so you are responsible for adding a maven repository that provides the dev login CLI artifact.
 
+### Per run configuration
+If you want to configure the dev login tool per run, you can do so by setting the following properties in your run configuration:
+```groovy
+runs {
+    someRun {
+        shouldUseDevLogin false
+    }
+}
+```
+This will disable the dev login tool for this run. By default, the dev login tool is enabled for all client runs.
+
+> [!WARNING]
+> If you enable the dev login tool for a none client run, you will get an error message.
+
 ## Centralized Cache
 NeoGradle has a centralized cache that can be used to store the decompiled Minecraft sources, the recompiled Minecraft sources, and other task outputs of complex tasks.
 The cache is enabled by default, and can be disabled by setting the following property in your gradle.properties:

--- a/README.md
+++ b/README.md
@@ -335,7 +335,6 @@ By default, the import in IDEA is run during the sync task.
 If you want to disable this, and use a post sync task, you can set the following property in your gradle.properties:
 ```properties
 neogradle.subsystems.conventions.ide.idea.use-post-sync-task=true
-
 ```
 
 ### Runs
@@ -365,6 +364,7 @@ The following properties can be used to configure the DevLogin tool:
 ```properties
 neogradle.subsystems.tools.devLogin=<artifact coordinate for devlogin cli tool>
 ```
+More information on the relevant tool, its released version and documentation can be found here: [DevLogin by Covers1624](https://github.com/covers1624/DevLogin)
 
 ## DevLogin
 The DevLogin tool is a tool that allows you to log in to a Minecraft account without having to use the Minecraft launcher, during development.

--- a/README.md
+++ b/README.md
@@ -383,7 +383,9 @@ If you want to configure the dev login tool per run, you can do so by setting th
 ```groovy
 runs {
     someRun {
-        useDevLogin true
+        devLogin {
+            enabled true
+        }
     }
 }
 ```
@@ -398,6 +400,18 @@ If you want to enable the dev login tool for all client runs, you can set the fo
 neogradle.subsystems.devLogin.conventionForRun=true
 ```
 This will enable the dev login tool for all client runs, unless explicitly disabled.
+
+Additionally, it is possible to use a different user profile for the dev login tool, by setting the following property in your run configuration:
+```groovy
+runs {
+    someRun {
+        devLogin {
+            profile '<profile>'
+        }
+    }
+}
+```
+If it is not set then the default profile will be used. See the DevLogin documentation for more information on profiles: [DevLogin by Covers1624](https://github.com/covers1624/DevLogin/blob/main/README.md#multiple-accounts)
 
 ### Configurations
 To add the dev login tool to your run we create a custom configuration to which we add the dev login tool.

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ The following properties can be used to configure the JST tool:
 neogradle.subsystems.tools.jst=<artifact coordinate for jst cli tool>
 ```
 ### DevLogin
-This tool is used by the runs subsystem to enable logged in plays on all client runs.
+This tool is used by the runs subsystem to enable Minecraft authentication in client runs.
 The following properties can be used to configure the DevLogin tool:
 ```properties
 neogradle.subsystems.tools.devLogin=<artifact coordinate for devlogin cli tool>
@@ -373,22 +373,15 @@ The tool can be configured using the following properties:
 ```properties
 neogradle.subsystems.devLogin.enabled=<true/false>
 ```
-By default, the subsystem is enabled, and it will ask you to log in when you run a client run.
-If you want to disable this, you can set the property to false, and then you will not be asked to log in, but use a random none signed in dev account.
-
-Additionally, you can configure whether to add the relevant repositories to your buildscript:
-```properties
-neogradle.subsystems.devLogin.addRepositories=<true/false>
-``` 
-By default, the repositories are added, but if you want to disable this, you can set the property to false.
-By doing so you are responsible for adding a maven repository that provides the dev login CLI artifact.
+By default, the subsystem is enabled, and it will prepare everything for you to log in to a Minecraft account, however you will still need to enable it on the runs you want.
+If you want to disable this you can set the property to false, and then you will not be asked to log in, but use a random non-signed in dev account.
 
 ### Per run configuration
 If you want to configure the dev login tool per run, you can do so by setting the following properties in your run configuration:
 ```groovy
 runs {
     someRun {
-        shouldUseDevLogin true
+        useDevLogin true
     }
 }
 ```
@@ -396,7 +389,17 @@ This will enable the dev login tool for this run.
 By default, the dev login tool is disabled, and can only be enabled for client runs.
 
 > [!WARNING]
-> If you enable the dev login tool for a none client run, you will get an error message.
+> If you enable the dev login tool for a non-client run, you will get an error message.
+
+### Configurations
+To add the dev login tool to your run we create a custom configuration to which we add the dev login tool.
+This configuration is created for the first source-set you register with the run as a mod source set.
+The suffix for the configuration can be configured to your personal preference, by setting the following property in your gradle.properties:
+```properties
+neogradle.subsystems.devLogin.configurationSuffix=<suffix>
+```
+By default, the suffix is set to "DevLoginLocalOnly".
+We use this approach to create a runtime only configuration, that does not leak to other consumers of your project.
 
 ## Centralized Cache
 NeoGradle has a centralized cache that can be used to store the decompiled Minecraft sources, the recompiled Minecraft sources, and other task outputs of complex tasks.
@@ -410,8 +413,8 @@ You can clean the artifacts that are stored in the cache by running the followin
 ./gradlew cleanCache
 ```
 
-This command is also automatically ran, when you run the clean task.
-The command will check if the stored artifact count is higher than the configured threshold, and if so remove the oldest artifacts until the count is below the threshold.
+This command is also automatically run, when you run the clean task.
+The command will check if the stored artifact count is higher than the configured threshold, and if so, remove the oldest artifacts until the count is below the threshold.
 The count is configured by the following property in your gradle.properties:
 ```properties
 net.neoforged.gradle.caching.maxCacheSize=<number>

--- a/README.md
+++ b/README.md
@@ -388,11 +388,12 @@ If you want to configure the dev login tool per run, you can do so by setting th
 ```groovy
 runs {
     someRun {
-        shouldUseDevLogin false
+        shouldUseDevLogin true
     }
 }
 ```
-This will disable the dev login tool for this run. By default, the dev login tool is disable, and can only be enabled for client runs.
+This will enable the dev login tool for this run. 
+By default, the dev login tool is disabled, and can only be enabled for client runs.
 
 > [!WARNING]
 > If you enable the dev login tool for a none client run, you will get an error message.

--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@ More information on the relevant tool, its released version and documentation ca
 
 ## DevLogin
 The DevLogin tool is a tool that allows you to log in to a Minecraft account without having to use the Minecraft launcher, during development.
+By default, it will use the credentials stored by the vanilla launcher, however if you are not logged in there, it will offer you the ability to log in directly from the console.
 This tool is used by the runs subsystem to enable logged in plays on all client runs.
 The tool can be configured using the following properties:
 ```properties
@@ -390,6 +391,12 @@ By default, the dev login tool is disabled, and can only be enabled for client r
 
 > [!WARNING]
 > If you enable the dev login tool for a non-client run, you will get an error message.
+
+If you want to enable the dev login tool for all client runs, you can set the following property in your gradle.properties:
+```properties
+neogradle.subsystems.devLogin.conventionForRun=true
+```
+This will enable the dev login tool for all client runs, unless explicitly disabled.
 
 ### Configurations
 To add the dev login tool to your run we create a custom configuration to which we add the dev login tool.

--- a/README.md
+++ b/README.md
@@ -368,7 +368,8 @@ More information on the relevant tool, its released version and documentation ca
 
 ## DevLogin
 The DevLogin tool is a tool that allows you to log in to a Minecraft account without having to use the Minecraft launcher, during development.
-By default, it will use the credentials stored by the vanilla launcher, however if you are not logged in there, it will offer you the ability to log in directly from the console.
+During first start it will show you a link to log in to your Minecraft account, and then you can use the tool to log in to your account.
+The credentials are cached on your local machine, and then reused for future logins, so that re-logging is only needed when the tokens expire.
 This tool is used by the runs subsystem to enable logged in plays on all client runs.
 The tool can be configured using the following properties:
 ```properties

--- a/common/src/main/java/net/neoforged/gradle/common/CommonProjectPlugin.java
+++ b/common/src/main/java/net/neoforged/gradle/common/CommonProjectPlugin.java
@@ -384,7 +384,7 @@ public class CommonProjectPlugin implements Plugin<Project> {
                     final Tools tools = project.getExtensions().getByType(Subsystems.class).getTools();
                     if (devLogin.getEnabled().get()) {
                         //Dev login is only supported on the client side
-                        if (runImpl.getIsClient().get()) {
+                        if (runImpl.getIsClient().get() && runImpl.getShouldUseDevLogin().get()) {
                             final String mainClass = runImpl.getMainClass().get();
 
                             //We add the dev login tool to the runtime only configuration, of the first source set, this should suffice
@@ -398,6 +398,8 @@ public class CommonProjectPlugin implements Plugin<Project> {
 
                             //Set the main class to the dev login tool
                             run.getMainClass().set("net.covers1624.devlogin.DevLogin");
+                        } else if (!runImpl.getIsClient().get() && runImpl.getShouldUseDevLogin().get()) {
+                            throw new GradleException("Dev login is only supported on runs which are marked as clients! The run: " + runImpl.getName() + " is not a client run.");
                         }
                     }
                 }

--- a/common/src/main/java/net/neoforged/gradle/common/CommonProjectPlugin.java
+++ b/common/src/main/java/net/neoforged/gradle/common/CommonProjectPlugin.java
@@ -347,7 +347,7 @@ public class CommonProjectPlugin implements Plugin<Project> {
                 }
 
                 if (run.getModSources().get().isEmpty()) {
-                    throw new GradleException("Run: " + run.getName() + " has no source sets configured. Please configure at least one source set.");
+                    throw new InvalidUserDataException("Run: " + run.getName() + " has no source sets configured. Please configure at least one source set.");
                 }
 
                 if (run.getConfigureFromDependencies().get()) {
@@ -384,7 +384,7 @@ public class CommonProjectPlugin implements Plugin<Project> {
                     final Tools tools = project.getExtensions().getByType(Subsystems.class).getTools();
                     if (devLogin.getEnabled().get()) {
                         //Dev login is only supported on the client side
-                        if (runImpl.getIsClient().get() && runImpl.getShouldUseDevLogin().get()) {
+                        if (runImpl.getIsClient().get() && runImpl.getUseDevLogin().get()) {
                             final String mainClass = runImpl.getMainClass().get();
 
                             //We add the dev login tool to the runtime only configuration, of the first source set, this should suffice
@@ -397,9 +397,9 @@ public class CommonProjectPlugin implements Plugin<Project> {
                             run.getProgramArguments().add(mainClass);
 
                             //Set the main class to the dev login tool
-                            run.getMainClass().set("net.covers1624.devlogin.DevLogin");
-                        } else if (!runImpl.getIsClient().get() && runImpl.getShouldUseDevLogin().get()) {
-                            throw new GradleException("Dev login is only supported on runs which are marked as clients! The run: " + runImpl.getName() + " is not a client run.");
+                            run.getMainClass().set(devLogin.getMainClass());
+                        } else if (!runImpl.getIsClient().get() && runImpl.getUseDevLogin().get()) {
+                            throw new InvalidUserDataException("Dev login is only supported on runs which are marked as clients! The run: " + runImpl.getName() + " is not a client run.");
                         }
                     }
                 }

--- a/common/src/main/java/net/neoforged/gradle/common/CommonProjectPlugin.java
+++ b/common/src/main/java/net/neoforged/gradle/common/CommonProjectPlugin.java
@@ -387,10 +387,14 @@ public class CommonProjectPlugin implements Plugin<Project> {
                         if (runImpl.getIsClient().get() && runImpl.getUseDevLogin().get()) {
                             final String mainClass = runImpl.getMainClass().get();
 
-                            //We add the dev login tool to the runtime only configuration, of the first source set, this should suffice
+                            //We add the dev login tool to a custom configuration which runtime classpath extends from the default runtime classpath
                             final SourceSet defaultSourceSet = runImpl.getModSources().get().get(0);
-                            final Configuration defaultRuntimeOnlyConfiguration = project.getConfigurations().maybeCreate(defaultSourceSet.getRuntimeOnlyConfigurationName());
-                            defaultRuntimeOnlyConfiguration.getDependencies().add(project.getDependencies().create(tools.getDevLogin().get()));
+                            final String runtimeOnlyDevLoginConfigurationName = ConfigurationUtils.getSourceSetName(defaultSourceSet, devLogin.getConfigurationSuffix().get());
+                            final Configuration sourceSetRuntimeOnlyDevLoginConfiguration = project.getConfigurations().maybeCreate(runtimeOnlyDevLoginConfigurationName);
+                            final Configuration sourceSetRuntimeClasspathConfiguration = project.getConfigurations().maybeCreate(defaultSourceSet.getRuntimeClasspathConfigurationName());
+
+                            sourceSetRuntimeClasspathConfiguration.extendsFrom(sourceSetRuntimeOnlyDevLoginConfiguration);
+                            sourceSetRuntimeOnlyDevLoginConfiguration.getDependencies().add(project.getDependencies().create(tools.getDevLogin().get()));
 
                             //Update the program arguments to properly launch the dev login tool
                             run.getProgramArguments().add("--launch_target");

--- a/common/src/main/java/net/neoforged/gradle/common/extensions/subsystems/SubsystemsExtension.java
+++ b/common/src/main/java/net/neoforged/gradle/common/extensions/subsystems/SubsystemsExtension.java
@@ -43,6 +43,9 @@ public abstract class SubsystemsExtension extends WithPropertyLookup implements 
         devLogin.getConfigurationSuffix().convention(
                 getStringProperty("devLogin.configurationSuffix").orElse("DevLoginLocalOnly")
         );
+        devLogin.getConventionForRun().convention(
+                getBooleanProperty("devLogin.conventionForRun").orElse(false)
+        );
     }
 
     private void configureToolsDefaults() {

--- a/common/src/main/java/net/neoforged/gradle/common/extensions/subsystems/SubsystemsExtension.java
+++ b/common/src/main/java/net/neoforged/gradle/common/extensions/subsystems/SubsystemsExtension.java
@@ -37,27 +37,9 @@ public abstract class SubsystemsExtension extends WithPropertyLookup implements 
         devLogin.getEnabled().convention(
                 getBooleanProperty("devLogin.enabled").orElse(true)
         );
-        devLogin.getAddRepository().convention(
-                getBooleanProperty("devLogin.addRepository").orElse(true)
-        );
         devLogin.getMainClass().convention(
                 getStringProperty("devLogin.mainClass").orElse(DEVLOGIN_MAIN_CLASS)
         );
-
-        // Add a filtered dev login repository automatically if enabled
-        project.afterEvaluate(p -> {
-            if (!devLogin.getEnabled().get() || !devLogin.getAddRepository().get()) {
-                return;
-            }
-            MavenArtifactRepository repo = p.getRepositories().maven(m -> {
-                m.setName("DevLogin Tool");
-                m.setUrl(URI.create(DEFAULT_DEVLOGIN_MAVEN_URL));
-                m.mavenContent(mavenContent -> mavenContent.includeGroup(DEFAULT_DEVLOGIN_GROUP));
-            });
-            // Make sure it comes first due to its filtered group, that should speed up resolution
-            p.getRepositories().remove(repo);
-            p.getRepositories().addFirst(repo);
-        });
     }
 
     private void configureToolsDefaults() {

--- a/common/src/main/java/net/neoforged/gradle/common/extensions/subsystems/SubsystemsExtension.java
+++ b/common/src/main/java/net/neoforged/gradle/common/extensions/subsystems/SubsystemsExtension.java
@@ -40,6 +40,9 @@ public abstract class SubsystemsExtension extends WithPropertyLookup implements 
         devLogin.getMainClass().convention(
                 getStringProperty("devLogin.mainClass").orElse(DEVLOGIN_MAIN_CLASS)
         );
+        devLogin.getConfigurationSuffix().convention(
+                getStringProperty("devLogin.configurationSuffix").orElse("DevLoginLocalOnly")
+        );
     }
 
     private void configureToolsDefaults() {

--- a/common/src/main/java/net/neoforged/gradle/common/extensions/subsystems/SubsystemsExtension.java
+++ b/common/src/main/java/net/neoforged/gradle/common/extensions/subsystems/SubsystemsExtension.java
@@ -40,6 +40,9 @@ public abstract class SubsystemsExtension extends WithPropertyLookup implements 
         devLogin.getAddRepository().convention(
                 getBooleanProperty("devLogin.addRepository").orElse(true)
         );
+        devLogin.getMainClass().convention(
+                getStringProperty("devLogin.mainClass").orElse(DEVLOGIN_MAIN_CLASS)
+        );
 
         // Add a filtered dev login repository automatically if enabled
         project.afterEvaluate(p -> {

--- a/common/src/main/java/net/neoforged/gradle/common/extensions/subsystems/SubsystemsExtension.java
+++ b/common/src/main/java/net/neoforged/gradle/common/extensions/subsystems/SubsystemsExtension.java
@@ -63,7 +63,7 @@ public abstract class SubsystemsExtension extends WithPropertyLookup implements 
                 getStringProperty("tools.jst").orElse(JST_TOOL_ARTIFACT)
         );
         tools.getDevLogin().convention(
-                getStringProperty("tools.devlogin").orElse(DEVLOGIN_TOOL_ARTIFACT)
+                getStringProperty("tools.devLogin").orElse(DEVLOGIN_TOOL_ARTIFACT)
         );
     }
 

--- a/common/src/main/java/net/neoforged/gradle/common/runs/run/RunImpl.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runs/run/RunImpl.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import net.minecraftforge.gdi.ConfigurableDSLElement;
 import net.neoforged.gradle.common.util.constants.RunsConstants;
+import net.neoforged.gradle.dsl.common.extensions.subsystems.Subsystems;
 import net.neoforged.gradle.dsl.common.runs.run.Run;
 import net.neoforged.gradle.dsl.common.runs.type.RunType;
 import net.neoforged.gradle.util.StringCapitalizationUtils;
@@ -61,7 +62,10 @@ public abstract class RunImpl implements ConfigurableDSLElement<Run>, Run {
         
         getWorkingDirectory().convention(project.getLayout().getProjectDirectory().dir("runs").dir(getName()));
 
-        getUseDevLogin().convention(false);
+        getUseDevLogin().convention(
+                project.getExtensions().getByType(Subsystems.class).getDevLogin().getConventionForRun()
+                        .zip(getIsClient(), (devLogin, isClient) -> devLogin && isClient)
+        );
     }
 
     @Override

--- a/common/src/main/java/net/neoforged/gradle/common/runs/run/RunImpl.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runs/run/RunImpl.java
@@ -61,7 +61,7 @@ public abstract class RunImpl implements ConfigurableDSLElement<Run>, Run {
         
         getWorkingDirectory().convention(project.getLayout().getProjectDirectory().dir("runs").dir(getName()));
 
-        getShouldUseDevLogin().convention(getIsClient());
+        getShouldUseDevLogin().convention(false);
     }
 
     @Override

--- a/common/src/main/java/net/neoforged/gradle/common/runs/run/RunImpl.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runs/run/RunImpl.java
@@ -60,6 +60,8 @@ public abstract class RunImpl implements ConfigurableDSLElement<Run>, Run {
         getConfigureFromDependencies().convention(getConfigureAutomatically());
         
         getWorkingDirectory().convention(project.getLayout().getProjectDirectory().dir("runs").dir(getName()));
+
+        getShouldUseDevLogin().convention(getIsClient());
     }
 
     @Override

--- a/common/src/main/java/net/neoforged/gradle/common/runs/run/RunImpl.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runs/run/RunImpl.java
@@ -61,11 +61,6 @@ public abstract class RunImpl implements ConfigurableDSLElement<Run>, Run {
         getConfigureFromDependencies().convention(getConfigureAutomatically());
         
         getWorkingDirectory().convention(project.getLayout().getProjectDirectory().dir("runs").dir(getName()));
-
-        getUseDevLogin().convention(
-                project.getExtensions().getByType(Subsystems.class).getDevLogin().getConventionForRun()
-                        .zip(getIsClient(), (devLogin, isClient) -> devLogin && isClient)
-        );
     }
 
     @Override

--- a/common/src/main/java/net/neoforged/gradle/common/runs/run/RunImpl.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runs/run/RunImpl.java
@@ -61,7 +61,7 @@ public abstract class RunImpl implements ConfigurableDSLElement<Run>, Run {
         
         getWorkingDirectory().convention(project.getLayout().getProjectDirectory().dir("runs").dir(getName()));
 
-        getShouldUseDevLogin().convention(false);
+        getUseDevLogin().convention(false);
     }
 
     @Override

--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/extensions/subsystems/DevLogin.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/extensions/subsystems/DevLogin.groovy
@@ -1,0 +1,31 @@
+package net.neoforged.gradle.dsl.common.extensions.subsystems
+
+import groovy.transform.CompileStatic
+import net.minecraftforge.gdi.ConfigurableDSLElement
+import net.minecraftforge.gdi.annotations.DSLProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+
+/**
+ * Allows configuration of the dev login system.
+ */
+@CompileStatic
+interface DevLogin extends ConfigurableDSLElement<DevLogin> {
+
+    /**
+     * @return Whether or not dev login is enabled on launch.
+     */
+    @Input
+    @Optional
+    @DSLProperty
+    Property<Boolean> getEnabled();
+
+    /**
+     * @return Whether or not to add the dev login repository to the project.
+     */
+    @Input
+    @Optional
+    @DSLProperty
+    Property<Boolean> getAddRepository();
+}

--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/extensions/subsystems/DevLogin.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/extensions/subsystems/DevLogin.groovy
@@ -36,4 +36,12 @@ interface DevLogin extends ConfigurableDSLElement<DevLogin> {
     @Optional
     @DSLProperty
     Property<String> getConfigurationSuffix()
+
+    /**
+     * @return The default usage flag state for runs. This is by default false (meaning the dev login configuration is not used by default), setting this to true will make all clients use dev login by default.
+     */
+    @Input
+    @Optional
+    @DSLProperty
+    Property<Boolean> getConventionForRun()
 }

--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/extensions/subsystems/DevLogin.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/extensions/subsystems/DevLogin.groovy
@@ -22,14 +22,6 @@ interface DevLogin extends ConfigurableDSLElement<DevLogin> {
     Property<Boolean> getEnabled();
 
     /**
-     * @return Whether or not to add the dev login repository to the project.
-     */
-    @Input
-    @Optional
-    @DSLProperty
-    Property<Boolean> getAddRepository();
-
-    /**
      * @return The main class to use when launching the game through dev login.
      */
     @Input

--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/extensions/subsystems/DevLogin.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/extensions/subsystems/DevLogin.groovy
@@ -28,4 +28,12 @@ interface DevLogin extends ConfigurableDSLElement<DevLogin> {
     @Optional
     @DSLProperty
     Property<Boolean> getAddRepository();
+
+    /**
+     * @return The main class to use when launching the game through dev login.
+     */
+    @Input
+    @Optional
+    @DSLProperty
+    Property<String> getMainClass();
 }

--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/extensions/subsystems/DevLogin.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/extensions/subsystems/DevLogin.groovy
@@ -28,4 +28,12 @@ interface DevLogin extends ConfigurableDSLElement<DevLogin> {
     @Optional
     @DSLProperty
     Property<String> getMainClass();
+
+    /**
+     * @return The suffix for the configuration name to use when adding the dev login configuration.
+     */
+    @Input
+    @Optional
+    @DSLProperty
+    Property<String> getConfigurationSuffix()
 }

--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/extensions/subsystems/Subsystems.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/extensions/subsystems/Subsystems.groovy
@@ -45,4 +45,11 @@ interface Subsystems extends BaseDSLElement<Subsystems> {
     @Nested
     @DSLProperty
     Tools getTools();
+
+    /**
+     * @return settings for the dev login subsystem
+     */
+    @Nested
+    @DSLProperty
+    DevLogin getDevLogin();
 }

--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/extensions/subsystems/Tools.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/extensions/subsystems/Tools.groovy
@@ -23,4 +23,12 @@ interface Tools extends ConfigurableDSLElement<Parchment> {
     @DSLProperty
     Property<String> getJST();
 
+    /**
+     * Artifact coordinates for the NeoGradle decompiler.
+     * Used by the runs subsystem to allow login to the dev environment.
+     */
+    @Input
+    @Optional
+    @DSLProperty
+    Property<String> getDevLogin();
 }

--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/runs/run/Run.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/runs/run/Run.groovy
@@ -1,5 +1,6 @@
 package net.neoforged.gradle.dsl.common.runs.run
 
+import groovy.cli.Option
 import groovy.transform.CompileStatic
 import net.minecraftforge.gdi.BaseDSLElement
 import net.minecraftforge.gdi.NamedDSLElement
@@ -155,6 +156,16 @@ interface Run extends BaseDSLElement<Run>, NamedDSLElement {
     @DSLProperty
     @Optional
     abstract Property<Boolean> getIsGameTest();
+
+    /**
+     * Indicates if this run should use the dev login.
+     *
+     * @return {@code true} if this run uses dev login; otherwise, {@code false}.
+     */
+    @Input
+    @DSLProperty
+    @Optional
+    abstract Property<Boolean> getShouldUseDevLogin();
 
     /**
      * Defines the source sets that are used as a mod.

--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/runs/run/Run.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/runs/run/Run.groovy
@@ -1,6 +1,6 @@
 package net.neoforged.gradle.dsl.common.runs.run
 
-import groovy.cli.Option
+
 import groovy.transform.CompileStatic
 import net.minecraftforge.gdi.BaseDSLElement
 import net.minecraftforge.gdi.NamedDSLElement
@@ -165,7 +165,7 @@ interface Run extends BaseDSLElement<Run>, NamedDSLElement {
     @Input
     @DSLProperty
     @Optional
-    abstract Property<Boolean> getShouldUseDevLogin();
+    abstract Property<Boolean> getUseDevLogin();
 
     /**
      * Defines the source sets that are used as a mod.

--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/runs/run/Run.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/runs/run/Run.groovy
@@ -158,16 +158,6 @@ interface Run extends BaseDSLElement<Run>, NamedDSLElement {
     abstract Property<Boolean> getIsGameTest();
 
     /**
-     * Indicates if this run should use the dev login.
-     *
-     * @return {@code true} if this run uses dev login; otherwise, {@code false}.
-     */
-    @Input
-    @DSLProperty
-    @Optional
-    abstract Property<Boolean> getUseDevLogin();
-
-    /**
      * Defines the source sets that are used as a mod.
      * <p>
      * For changing the mod identifier a source set belongs to see
@@ -241,7 +231,6 @@ interface Run extends BaseDSLElement<Run>, NamedDSLElement {
     @DSLProperty
     @Optional
     abstract Property<Boolean> getConfigureFromDependencies();
-
 
     /**
      * Configures the run using the settings of the associated run type.

--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/runs/run/RunDevLogin.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/runs/run/RunDevLogin.groovy
@@ -1,0 +1,35 @@
+package net.neoforged.gradle.dsl.common.runs.run
+
+import groovy.transform.CompileStatic
+import net.minecraftforge.gdi.ConfigurableDSLElement
+import net.minecraftforge.gdi.annotations.DSLProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+
+/**
+ * Defines the object structure for the dev login configuration of a run
+ */
+@CompileStatic
+interface RunDevLogin extends ConfigurableDSLElement<RunDevLogin> {
+
+    /**
+     * Indicates if the dev login is enabled.
+     * Its default value is dependent on {@link net.neoforged.gradle.dsl.common.extensions.subsystems.DevLogin#getConventionForRun}.
+     *
+     * @return {@code true} if the dev login is enabled; otherwise, {@code false}.
+     */
+    @Input
+    @Optional
+    @DSLProperty
+    Property<Boolean> getIsEnabled()
+
+    /**
+     * This is the profile name that is used when launching the game through dev login.
+     * It is used as the key for looking up credentials in the credentials file, or for creating a new profile.
+     */
+    @Input
+    @Optional
+    @DSLProperty
+    Property<String> getProfile()
+}

--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/util/Constants.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/util/Constants.groovy
@@ -28,6 +28,11 @@ class Constants {
     public static final String DEFAULT_PARCHMENT_ARTIFACT_PREFIX = "parchment-"
     public static final String DEFAULT_PARCHMENT_MAVEN_URL = "https://maven.parchmentmc.org/"
     public static final String JST_TOOL_ARTIFACT = "net.neoforged.jst:jst-cli-bundle:1.0.36"
+    public static final String DEFAULT_DEVLOGIN_GROUP = "net.covers1624"
+    public static final String DEFAULT_DEVLOGIN_ARTIFACT = "DevLogin"
+    public static final String DEFAULT_DEVLOGIN_MAVEN_URL = "https://maven.covers1624.net/"
+    public static final String DEVLOGIN_TOOL_ARTIFACT = "net.covers1624:DevLogin:0.1.0.3"
+    public static final String DEVLOGIN_MAIN_CLASS = "net.covers1624.devlogin.DevLogin"
 
     public static final String DEFAULT_RECOMPILER_MAX_MEMORY = "1g"
 

--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/util/Constants.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/util/Constants.groovy
@@ -30,8 +30,7 @@ class Constants {
     public static final String JST_TOOL_ARTIFACT = "net.neoforged.jst:jst-cli-bundle:1.0.36"
     public static final String DEFAULT_DEVLOGIN_GROUP = "net.covers1624"
     public static final String DEFAULT_DEVLOGIN_ARTIFACT = "DevLogin"
-    public static final String DEFAULT_DEVLOGIN_MAVEN_URL = "https://maven.covers1624.net/"
-    public static final String DEVLOGIN_TOOL_ARTIFACT = "net.covers1624:DevLogin:0.1.0.3"
+    public static final String DEVLOGIN_TOOL_ARTIFACT = "net.covers1624:DevLogin:0.1.0.4"
     public static final String DEVLOGIN_MAIN_CLASS = "net.covers1624.devlogin.DevLogin"
 
     public static final String DEFAULT_RECOMPILER_MAX_MEMORY = "1g"

--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/util/Constants.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/util/Constants.groovy
@@ -28,8 +28,6 @@ class Constants {
     public static final String DEFAULT_PARCHMENT_ARTIFACT_PREFIX = "parchment-"
     public static final String DEFAULT_PARCHMENT_MAVEN_URL = "https://maven.parchmentmc.org/"
     public static final String JST_TOOL_ARTIFACT = "net.neoforged.jst:jst-cli-bundle:1.0.36"
-    public static final String DEFAULT_DEVLOGIN_GROUP = "net.covers1624"
-    public static final String DEFAULT_DEVLOGIN_ARTIFACT = "DevLogin"
     public static final String DEVLOGIN_TOOL_ARTIFACT = "net.covers1624:DevLogin:0.1.0.4"
     public static final String DEVLOGIN_MAIN_CLASS = "net.covers1624.devlogin.DevLogin"
 

--- a/userdev/src/functionalTest/groovy/net/neoforged/gradle/userdev/convention/SourceSetConventionTests.groovy
+++ b/userdev/src/functionalTest/groovy/net/neoforged/gradle/userdev/convention/SourceSetConventionTests.groovy
@@ -244,6 +244,7 @@ class SourceSetConventionTests extends BuilderBasedTestSpecification {
         when:
         def run = project.run {
             it.tasks(':dependencies')
+            it.shouldFail()
         }
 
         then:
@@ -284,6 +285,7 @@ class SourceSetConventionTests extends BuilderBasedTestSpecification {
         when:
         def run = project.run {
             it.tasks(':dependencies')
+            it.shouldFail()
         }
 
         then:
@@ -324,6 +326,7 @@ class SourceSetConventionTests extends BuilderBasedTestSpecification {
         when:
         def run = project.run {
             it.tasks(':dependencies')
+            it.shouldFail()
         }
 
         then:


### PR DESCRIPTION
### TLDR: 
- This adds supports for DevLogin on client runs

---

### DevLogin Support:
We now support the use of DevLogin by @covers1624.
You can use the following DSL to enable it:
```groovy
runs {
    someRun {
        devLogin {
           enabled true
        }
    }
}
```
By default the tool is disabled on all client runs.

> [!WARNING]
> If you enable the dev login tool for a none client run, you will get an error message.

### Better error handling:
There is now better error handling if you do not configure mod sources in a run.

### Closes:
Closes: #100