### PR TITLE
Fix unpackSourcePatches and generate binary patches

### DIFF
--- a/common/src/main/java/net/neoforged/gradle/common/caching/CentralCacheService.java
+++ b/common/src/main/java/net/neoforged/gradle/common/caching/CentralCacheService.java
@@ -285,7 +285,7 @@ public abstract class CentralCacheService implements BuildService<CentralCacheSe
                 for (Path path : Files.walk(file.toPath()).filter(Files::isRegularFile).toList()) {
                     debugLog(task, "Hashing task input file: " + path.toAbsolutePath());
                     hasher.putString(path.getFileName().toString());
-                    final HashCode code = hashFunction.hashFile(file);
+                    final HashCode code = hashFunction.hashFile(path.toFile());
                     debugLog(task, "Hashing task input file hash: " + code);
                     hasher.putHash(code);
                 }

--- a/common/src/main/java/net/neoforged/gradle/common/caching/CentralCacheService.java
+++ b/common/src/main/java/net/neoforged/gradle/common/caching/CentralCacheService.java
@@ -282,11 +282,13 @@ public abstract class CentralCacheService implements BuildService<CentralCacheSe
             });
 
             for (File file : inputs.getFiles()) {
-                debugLog(task, "Hashing task input file: " + file.getAbsolutePath());
-                hasher.putString(file.getName());
-                final HashCode code = hashFunction.hashFile(file);
-                debugLog(task, "Hashing task input file hash: " + code);
-                hasher.putHash(code);
+                for (Path path : Files.walk(file.toPath()).filter(Files::isRegularFile).toList()) {
+                    debugLog(task, "Hashing task input file: " + path.toAbsolutePath());
+                    hasher.putString(path.getFileName().toString());
+                    final HashCode code = hashFunction.hashFile(file);
+                    debugLog(task, "Hashing task input file hash: " + code);
+                    hasher.putHash(code);
+                }
             }
         }
 

--- a/platform/src/main/java/net/neoforged/gradle/platform/extensions/DynamicProjectExtension.java
+++ b/platform/src/main/java/net/neoforged/gradle/platform/extensions/DynamicProjectExtension.java
@@ -273,7 +273,7 @@ public abstract class DynamicProjectExtension implements BaseDSLElement<DynamicP
                     task.getClean().set(cleanProvider.flatMap(WithOutput::getOutput));
                     task.getPatched().set(compiledJarProvider.flatMap(Jar::getArchiveFile));
                     task.getDistributionType().set(distribution);
-                    task.getPatches().from(project.fileTree(patches));
+                    task.getPatches().from(patches);
                     task.getMappings().set(obfToMojMappingProviders.get(distribution).flatMap(WithOutput::getOutput));
                     
                     task.mustRunAfter(unpackZip);

--- a/platform/src/main/java/net/neoforged/gradle/platform/extensions/DynamicProjectExtension.java
+++ b/platform/src/main/java/net/neoforged/gradle/platform/extensions/DynamicProjectExtension.java
@@ -250,7 +250,7 @@ public abstract class DynamicProjectExtension implements BaseDSLElement<DynamicP
             });
             
             final TaskProvider<? extends UnpackZip> unpackZip = project.getTasks().register("unpackSourcePatches", UnpackZip.class, task -> {
-                task.getInput().from(createPatches.flatMap(WithOutput::getOutput));
+                task.getInput().from(project.zipTree(createPatches.flatMap(WithOutput::getOutput)));
                 task.getUnpackingTarget().set(patches);
                 
                 CommonRuntimeExtension.configureCommonRuntimeTaskParameters(task, runtimeDefinition, workingDirectory);
@@ -273,7 +273,7 @@ public abstract class DynamicProjectExtension implements BaseDSLElement<DynamicP
                     task.getClean().set(cleanProvider.flatMap(WithOutput::getOutput));
                     task.getPatched().set(compiledJarProvider.flatMap(Jar::getArchiveFile));
                     task.getDistributionType().set(distribution);
-                    task.getPatches().from(patches);
+                    task.getPatches().from(project.fileTree(patches));
                     task.getMappings().set(obfToMojMappingProviders.get(distribution).flatMap(WithOutput::getOutput));
                     
                     task.mustRunAfter(unpackZip);


### PR DESCRIPTION
Fixes `unpackSourcePatches` outputting a jar by using a `zipTree` and `generateClientBinaryPatches` trying to hash a folder as a regular file by instead hashing all the files in the folder.