### PR TITLE
[Feature] Introduce the possibility to manual group sourcesets together

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,11 +204,15 @@ To include the sibling project in your run, you need to add it as a modSource to
 ```groovy
 runs {
     someRun {
-        modSource sourceSets.main
-        modSource project(':siblingProject').sourceSets.main
+        modSources {
+            add project.sourceSets.main // Adds the owning projects main sourceset to a group based on that sourcesets mod identifier (could be anything here, depending on the sourcesets extension values, or the project name)
+            add project(':api').sourceSets.main // Assuming the API project is not using NeoGradle, this would add the api project to a group using the `api` key, because the default mod identifier for non-neogradle projects is the projects name, here api
+            local project(':api').sourceSets.main // Assuming the API project is not using NeoGradle, this would add the api project to a group using the owning projects name, instead of the api projects name as a fallback (could be anything here, depending on the sourcesets extension values, or the project name)
+            add('something', project(':api').sourceSets.main) // This hardcodes the group identifier to 'something', performing no lookup of the mod identifier on the sourceset, or using the owning project, or the sourcesets project.
+        }
     }
 }
-``` 
+```
 No other action is needed.
 
 ## Using conventions

--- a/common/src/main/java/net/neoforged/gradle/common/CommonProjectPlugin.java
+++ b/common/src/main/java/net/neoforged/gradle/common/CommonProjectPlugin.java
@@ -360,7 +360,7 @@ public class CommonProjectPlugin implements Plugin<Project> {
                     }
                 }
 
-                if (run.getModSources().get().isEmpty()) {
+                if (run.getModSources().all().get().isEmpty()) {
                     throw new InvalidUserDataException("Run: " + run.getName() + " has no source sets configured. Please configure at least one source set.");
                 }
 
@@ -404,7 +404,7 @@ public class CommonProjectPlugin implements Plugin<Project> {
                             final String mainClass = runImpl.getMainClass().get();
 
                             //We add the dev login tool to a custom configuration which runtime classpath extends from the default runtime classpath
-                            final SourceSet defaultSourceSet = runImpl.getModSources().get().get(0);
+                            final SourceSet defaultSourceSet = runImpl.getModSources().all().get().entries().iterator().next().getValue();
                             final String runtimeOnlyDevLoginConfigurationName = ConfigurationUtils.getSourceSetName(defaultSourceSet, devLogin.getConfigurationSuffix().get());
                             final Configuration sourceSetRuntimeOnlyDevLoginConfiguration = project.getConfigurations().maybeCreate(runtimeOnlyDevLoginConfigurationName);
                             final Configuration sourceSetRuntimeClasspathConfiguration = project.getConfigurations().maybeCreate(defaultSourceSet.getRuntimeClasspathConfigurationName());

--- a/common/src/main/java/net/neoforged/gradle/common/CommonProjectPlugin.java
+++ b/common/src/main/java/net/neoforged/gradle/common/CommonProjectPlugin.java
@@ -8,6 +8,7 @@ import net.neoforged.gradle.common.extensions.repository.IvyRepository;
 import net.neoforged.gradle.common.extensions.subsystems.SubsystemsExtension;
 import net.neoforged.gradle.common.runs.ide.IdeRunIntegrationManager;
 import net.neoforged.gradle.common.runs.run.RunImpl;
+import net.neoforged.gradle.common.runs.tasks.RunsReport;
 import net.neoforged.gradle.common.runtime.definition.CommonRuntimeDefinition;
 import net.neoforged.gradle.common.runtime.extensions.RuntimesExtension;
 import net.neoforged.gradle.common.runtime.naming.OfficialNamingChannelConfigurator;
@@ -149,6 +150,9 @@ public class CommonProjectPlugin implements Plugin<Project> {
         //Needs to be before after evaluate
         configureConventions(project);
 
+        //Set up reporting tasks
+        project.getTasks().register("runs", RunsReport.class);
+
         project.afterEvaluate(this::applyAfterEvaluate);
     }
 
@@ -188,7 +192,7 @@ public class CommonProjectPlugin implements Plugin<Project> {
                     }
 
                     if (sourceSets.getShouldSourceSetsLocalRunRuntimesBeAutomaticallyAddedToRuns().get() && configurations.getIsEnabled().get()) {
-                        run.getModSources().get().forEach(sourceSet -> {
+                        run.getModSources().all().get().values().forEach(sourceSet -> {
                             if (project.getConfigurations().findByName(ConfigurationUtils.getSourceSetName(sourceSet, configurations.getRunRuntimeConfigurationPostFix().get())) != null) {
                                 run.getDependencies().get().getRuntime().add(project.getConfigurations().getByName(ConfigurationUtils.getSourceSetName(sourceSet, configurations.getRunRuntimeConfigurationPostFix().get())));
                             }
@@ -353,7 +357,7 @@ public class CommonProjectPlugin implements Plugin<Project> {
                     //TODO: Determine handling of multiple different runtimes, in multiple projects....
                     final Map<String, CommonRuntimeDefinition<?>> definitionSet = new HashMap<>();
 
-                    runImpl.getModSources().get().forEach(sourceSet -> {
+                    runImpl.getModSources().all().get().values().forEach(sourceSet -> {
                         try {
                             final Optional<CommonRuntimeDefinition<?>> definition = TaskDependencyUtils.findRuntimeDefinition(sourceSet);
                             if (definition.isPresent()) {

--- a/common/src/main/java/net/neoforged/gradle/common/runs/ide/IdeRunIntegrationManager.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runs/ide/IdeRunIntegrationManager.java
@@ -1,5 +1,6 @@
 package net.neoforged.gradle.common.runs.ide;
 
+import com.google.common.collect.Multimap;
 import net.neoforged.elc.configs.GradleLaunchConfig;
 import net.neoforged.elc.configs.JavaApplicationLaunchConfig;
 import net.neoforged.elc.configs.LaunchConfig;
@@ -255,7 +256,7 @@ public class IdeRunIntegrationManager {
 
         private List<TaskProvider<?>> createEclipseCopyResourcesTasks(EclipseModel eclipse, Run run) {
             final List<TaskProvider<?>> copyProcessResources = new ArrayList<>();
-            for (SourceSet sourceSet : run.getModSources().get()) {
+            for (SourceSet sourceSet : run.getModSources().all().get().values()) {
                 final Project sourceSetProject = SourceSetUtils.getProject(sourceSet);
 
                 final String taskName = CommonRuntimeUtils.buildTaskName("eclipseCopy", sourceSet.getProcessResourcesTaskName());
@@ -302,10 +303,10 @@ public class IdeRunIntegrationManager {
         
         private static Map<String, String> adaptEnvironment(
                 final RunImpl run,
-                final Function<ListProperty<SourceSet>, Provider<String>> modClassesProvider
+                final Function<Provider<Multimap<String, SourceSet>>, Provider<String>> modClassesProvider
                 ) {
             final Map<String, String> environment = new HashMap<>(run.getEnvironmentVariables().get());
-            environment.put("MOD_CLASSES", modClassesProvider.apply(run.getModSources()).get());
+            environment.put("MOD_CLASSES", modClassesProvider.apply(run.getModSources().all()).get());
             return environment;
         }
     }

--- a/common/src/main/java/net/neoforged/gradle/common/runs/run/RunImpl.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runs/run/RunImpl.java
@@ -5,6 +5,7 @@ import com.google.common.collect.Sets;
 import net.minecraftforge.gdi.ConfigurableDSLElement;
 import net.neoforged.gradle.common.util.constants.RunsConstants;
 import net.neoforged.gradle.dsl.common.runs.run.Run;
+import net.neoforged.gradle.dsl.common.runs.run.RunSourceSets;
 import net.neoforged.gradle.dsl.common.runs.type.RunType;
 import net.neoforged.gradle.util.StringCapitalizationUtils;
 import org.gradle.api.GradleException;
@@ -16,6 +17,7 @@ import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskProvider;
 import org.jetbrains.annotations.NotNull;
 
@@ -26,19 +28,23 @@ public abstract class RunImpl implements ConfigurableDSLElement<Run>, Run {
 
     private final Project project;
     private final String name;
+    private final ListProperty<RunType> runTypes;
+    private final Set<TaskProvider<? extends Task>> dependencies = Sets.newHashSet();
+    private final RunSourceSets modSources;
+    private final RunSourceSets unitTestSources;
 
     private ListProperty<String> jvmArguments;
     private MapProperty<String, String> environmentVariables;
     private ListProperty<String> programArguments;
     private MapProperty<String, String> systemProperties;
-    private final ListProperty<RunType> runTypes;
 
-    private final Set<TaskProvider<? extends Task>> dependencies = Sets.newHashSet();
 
     @Inject
     public RunImpl(final Project project, final String name) {
         this.project = project;
         this.name = name;
+        this.modSources = project.getObjects().newInstance(RunSourceSetImpl.class, project);
+        this.unitTestSources = project.getObjects().newInstance(RunSourceSetImpl.class, project);
 
         this.jvmArguments = this.project.getObjects().listProperty(String.class);
         this.environmentVariables = this.project.getObjects().mapProperty(String.class, String.class);
@@ -85,6 +91,46 @@ public abstract class RunImpl implements ConfigurableDSLElement<Run>, Run {
 
     @Override
     public abstract Property<Boolean> getShouldBuildAllProjects();
+
+    @Override
+    public RunSourceSets getUnitTestSources() {
+        return this.unitTestSources;
+    }
+
+    @Override
+    public void unitTestSource(@NotNull final SourceSet sourceSet) {
+        getUnitTestSources().add(sourceSet);
+    }
+
+    @Override
+    public void unitTestSources(@NotNull final SourceSet... sourceSets) {
+        getUnitTestSources().add(sourceSets);
+    }
+
+    @Override
+    public void unitTestSources(@NotNull final Iterable<? extends SourceSet> sourceSets) {
+        getUnitTestSources().add(sourceSets);
+    }
+
+    @Override
+    public RunSourceSets getModSources() {
+        return this.modSources;
+    }
+
+    @Override
+    public void modSource(@NotNull final SourceSet sourceSet) {
+        getModSources().add(sourceSet);
+    }
+
+    @Override
+    public void modSources(@NotNull final SourceSet... sourceSets) {
+        getModSources().add(sourceSets);
+    }
+
+    @Override
+    public void modSources(@NotNull final Iterable<? extends SourceSet> sourceSets) {
+        getModSources().add(sourceSets);
+    }
 
     @Override
     public ListProperty<String> getProgramArguments() {

--- a/common/src/main/java/net/neoforged/gradle/common/runs/run/RunImpl.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runs/run/RunImpl.java
@@ -43,8 +43,8 @@ public abstract class RunImpl implements ConfigurableDSLElement<Run>, Run {
     public RunImpl(final Project project, final String name) {
         this.project = project;
         this.name = name;
-        this.modSources = project.getObjects().newInstance(RunSourceSetImpl.class, project);
-        this.unitTestSources = project.getObjects().newInstance(RunSourceSetImpl.class, project);
+        this.modSources = project.getObjects().newInstance(RunSourceSetsImpl.class, project);
+        this.unitTestSources = project.getObjects().newInstance(RunSourceSetsImpl.class, project);
 
         this.jvmArguments = this.project.getObjects().listProperty(String.class);
         this.environmentVariables = this.project.getObjects().mapProperty(String.class, String.class);

--- a/common/src/main/java/net/neoforged/gradle/common/runs/run/RunSourceSetImpl.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runs/run/RunSourceSetImpl.java
@@ -1,0 +1,86 @@
+package net.neoforged.gradle.common.runs.run;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import net.neoforged.gradle.common.util.SourceSetUtils;
+import net.neoforged.gradle.dsl.common.runs.run.RunSourceSets;
+import org.gradle.api.Project;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.SourceSet;
+
+import javax.inject.Inject;
+
+public abstract class RunSourceSetImpl implements RunSourceSets {
+
+    private final Project project;
+    private final Provider<Multimap<String, SourceSet>> provider;
+    private final Multimap<String, SourceSet> sourceSets;
+
+    @Inject
+    public RunSourceSetImpl(Project project) {
+        this.project = project;
+        this.sourceSets = HashMultimap.create();
+        this.provider = project.provider(() -> sourceSets);
+    }
+
+
+    @Override
+    public void add(SourceSet sourceSet) {
+        this.sourceSets.put(SourceSetUtils.getModIdentifier(sourceSet, null), sourceSet);
+    }
+
+    @Override
+    public void add(Iterable<? extends SourceSet> sourceSets) {
+        for (SourceSet sourceSet : sourceSets) {
+            add(sourceSet);
+        }
+    }
+
+    @Override
+    public void add(SourceSet... sourceSets) {
+        for (SourceSet sourceSet : sourceSets) {
+            add(sourceSet);
+        }
+    }
+
+    @Override
+    public void local(SourceSet sourceSet) {
+        this.sourceSets.put(SourceSetUtils.getModIdentifier(sourceSet, project), sourceSet);
+    }
+
+    @Override
+    public void local(Iterable<? extends SourceSet> sourceSets) {
+        for (SourceSet sourceSet : sourceSets) {
+            local(sourceSet);
+        }
+    }
+
+    @Override
+    public void local(SourceSet... sourceSets) {
+        for (SourceSet sourceSet : sourceSets) {
+            local(sourceSet);
+        }
+    }
+
+    @Override
+    public void add(String groupId, SourceSet sourceSet) {
+        this.sourceSets.put(groupId, sourceSet);
+    }
+
+    @Override
+    public void add(String groupId, Iterable<? extends SourceSet> sourceSets) {
+        this.sourceSets.putAll(groupId, sourceSets);
+    }
+
+    @Override
+    public void add(String groupId, SourceSet... sourceSets) {
+        for (SourceSet sourceSet : sourceSets) {
+            add(groupId, sourceSet);
+        }
+    }
+
+    @Override
+    public Provider<Multimap<String, SourceSet>> all() {
+        return this.provider;
+    }
+}

--- a/common/src/main/java/net/neoforged/gradle/common/runs/run/RunSourceSetsImpl.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runs/run/RunSourceSetsImpl.java
@@ -10,14 +10,14 @@ import org.gradle.api.tasks.SourceSet;
 
 import javax.inject.Inject;
 
-public abstract class RunSourceSetImpl implements RunSourceSets {
+public abstract class RunSourceSetsImpl implements RunSourceSets {
 
     private final Project project;
     private final Provider<Multimap<String, SourceSet>> provider;
     private final Multimap<String, SourceSet> sourceSets;
 
     @Inject
-    public RunSourceSetImpl(Project project) {
+    public RunSourceSetsImpl(Project project) {
         this.project = project;
         this.sourceSets = HashMultimap.create();
         this.provider = project.provider(() -> sourceSets);

--- a/common/src/main/java/net/neoforged/gradle/common/runs/tasks/RunExec.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runs/tasks/RunExec.java
@@ -39,7 +39,7 @@ public abstract class RunExec extends JavaExec {
         environment(run.getEnvironmentVariables().get());
         systemProperties(run.getSystemProperties().get());
 
-        run.getModSources().get().stream()
+        run.getModSources().all().get().values().stream()
                 .map(SourceSet::getRuntimeClasspath)
                 .forEach(this::classpath);
 

--- a/common/src/main/java/net/neoforged/gradle/common/runs/tasks/RunsReport.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runs/tasks/RunsReport.java
@@ -1,0 +1,405 @@
+package net.neoforged.gradle.common.runs.tasks;
+
+import com.google.common.collect.Multimap;
+import net.neoforged.gradle.common.util.constants.RunsConstants;
+import net.neoforged.gradle.dsl.common.runs.run.Run;
+import org.gradle.api.NamedDomainObjectContainer;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.diagnostics.AbstractProjectBasedReportTask;
+import org.gradle.api.tasks.diagnostics.internal.ProjectDetails;
+import org.gradle.api.tasks.diagnostics.internal.ReportRenderer;
+import org.gradle.api.tasks.diagnostics.internal.TextReportRenderer;
+import org.gradle.internal.logging.text.StyledTextOutput;
+import org.gradle.work.DisableCachingByDefault;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@DisableCachingByDefault(
+        because = "Not worth caching"
+)
+public abstract class RunsReport extends AbstractProjectBasedReportTask<RunsReport.RunsProjectReport> {
+
+    private final Renderer renderer = new Renderer();
+
+    @Override
+    protected ReportRenderer getRenderer() {
+        return renderer;
+    }
+
+    @Override
+    protected void generateReportFor(@NotNull ProjectDetails project, @NotNull RunsReport.RunsProjectReport model) {
+        model.getRuns().forEach(renderer::renderRun);
+        renderer.completeProject(project);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    protected @NotNull RunsReport.RunsProjectReport calculateReportModelFor(@NotNull Project project) {
+        final NamedDomainObjectContainer<Run> runs = (NamedDomainObjectContainer<Run>) project.getExtensions().getByName(RunsConstants.Extensions.RUNS);
+        final RunsProjectReport report = new RunsProjectReport();
+        runs.forEach(run -> {
+            report.addRun(new RenderableRun(run));
+        });
+        return report;
+    }
+
+    public static class RunsProjectReport {
+
+        private final List<RenderableRun> runs;
+
+        public RunsProjectReport() {
+            runs = new ArrayList<>();
+        }
+
+        public void addRun(RenderableRun run) {
+            runs.add(run);
+        }
+
+        public List<RenderableRun> getRuns() {
+            return runs;
+        }
+    }
+
+    public static class RenderableRun {
+        private final String name;
+        private final Map<String, String> environment;
+        private final String mainClass;
+        private final boolean shouldBuildAllProjects;
+        private final Map<String, String> properties;
+        private final List<String> programArguments;
+        private final List<String> jvmArguments;
+        private final boolean isSingleInstance;
+        private final String workingDirectory;
+        private final boolean isClient;
+        private final boolean isServer;
+        private final boolean isData;
+        private final boolean isJUnit;
+        private final boolean isGameTest;
+        private final Multimap<String, SourceSet> modSources;
+        private final Multimap<String, SourceSet> unitTestSources;
+        private final Set<String> classpath;
+        private final Set<String> dependencies;
+
+        public RenderableRun(Run run) {
+            this.name = run.getName();
+            this.environment = run.getEnvironmentVariables().get();
+            this.mainClass = run.getMainClass().get();
+            this.shouldBuildAllProjects = run.getShouldBuildAllProjects().get();
+            this.properties = run.getSystemProperties().get();
+            this.programArguments = run.getProgramArguments().get();
+            this.jvmArguments = run.getJvmArguments().get();
+            this.isSingleInstance = run.getIsSingleInstance().get();
+            this.workingDirectory = run.getWorkingDirectory().get().getAsFile().getAbsolutePath();
+            this.isClient = run.getIsClient().get();
+            this.isServer = run.getIsServer().get();
+            this.isData = run.getIsDataGenerator().get();
+            this.isJUnit = run.getIsJUnit().get();
+            this.isGameTest = run.getIsGameTest().get();
+            this.modSources = run.getModSources().all().get();
+            this.unitTestSources = run.getUnitTestSources().all().get();
+            this.classpath = run.getClasspath().getFiles().stream().map(File::getAbsolutePath).collect(Collectors.toSet());
+            this.dependencies = run.getDependencies().get().getRuntimeConfiguration().getFiles().stream().map(File::getAbsolutePath).collect(Collectors.toSet());
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public Map<String, String> getEnvironment() {
+            return environment;
+        }
+
+        public String getMainClass() {
+            return mainClass;
+        }
+
+        public boolean isShouldBuildAllProjects() {
+            return shouldBuildAllProjects;
+        }
+
+        public Map<String, String> getProperties() {
+            return properties;
+        }
+
+        public List<String> getProgramArguments() {
+            return programArguments;
+        }
+
+        public List<String> getJvmArguments() {
+            return jvmArguments;
+        }
+
+        public boolean isSingleInstance() {
+            return isSingleInstance;
+        }
+
+        public String getWorkingDirectory() {
+            return workingDirectory;
+        }
+
+        public boolean isClient() {
+            return isClient;
+        }
+
+        public boolean isServer() {
+            return isServer;
+        }
+
+        public boolean isData() {
+            return isData;
+        }
+
+        public boolean isJUnit() {
+            return isJUnit;
+        }
+
+        public boolean isGameTest() {
+            return isGameTest;
+        }
+
+        public Multimap<String, SourceSet> getModSources() {
+            return modSources;
+        }
+
+        public Multimap<String, SourceSet> getUnitTestSources() {
+            return unitTestSources;
+        }
+
+        public Set<String> getClasspath() {
+            return classpath;
+        }
+
+        public Set<String> getDependencies() {
+            return dependencies;
+        }
+    }
+
+    public static class Renderer extends TextReportRenderer {
+
+        private boolean hasRuns = false;
+
+        @Override
+        public void completeProject(ProjectDetails project) {
+            super.completeProject(project);
+            if (!hasRuns) {
+                getTextOutput().text("  - No Runs");
+            }
+        }
+
+        private void outputHeader(String header) {
+            getTextOutput().withStyle(StyledTextOutput.Style.Header).text(header);
+            outputNewLine();
+            outputNormal("----------------------------------------------------------");
+        }
+
+        private void outputIdentifier(String identifier) {
+            getTextOutput().withStyle(StyledTextOutput.Style.Identifier).text(identifier);
+        }
+
+        private void outputNormal(String normal) {
+            getTextOutput().withStyle(StyledTextOutput.Style.Normal).text(normal);
+        }
+
+        private void outputError(String error) {
+            getTextOutput().withStyle(StyledTextOutput.Style.Error).text(error);
+        }
+
+        private void outputNewLine() {
+            getTextOutput().println();
+        }
+
+        private void renderRun(RenderableRun run) {
+            if (hasRuns) {
+                getTextOutput().println();
+            }
+
+            outputHeader("Run: " + run.getName());
+            outputNewLine();
+            outputIdentifier("Main Class:");
+            outputNormal(run.getMainClass());
+            outputNewLine();
+            outputIdentifier("Should Build All Projects:");
+            outputNormal(String.valueOf(run.isShouldBuildAllProjects()));
+            outputNewLine();
+            outputIdentifier("Working Directory:");
+            outputNormal(run.getWorkingDirectory());
+            outputNewLine();
+            outputIdentifier("Is Single Instance:");
+            outputNormal(String.valueOf(run.isSingleInstance()));
+            outputNewLine();
+            outputIdentifier("Is Client:");
+            outputNormal(String.valueOf(run.isClient()));
+            outputNewLine();
+            outputIdentifier("Is Server:");
+            outputNormal(String.valueOf(run.isServer()));
+            outputNewLine();
+            outputIdentifier("Is Data Generator:");
+            outputNormal(String.valueOf(run.isData()));
+            outputNewLine();
+            outputIdentifier("Is JUnit:");
+            outputNormal(String.valueOf(run.isJUnit()));
+            outputNewLine();
+            outputIdentifier("Is Game Test:");
+            outputNormal(String.valueOf(run.isGameTest()));
+            outputNewLine();
+
+            renderEnvironment(run.getEnvironment());
+            renderProperties(run.getProperties());
+            renderProgramArguments(run.getProgramArguments());
+            renderJvmArguments(run.getJvmArguments());
+            renderModSources(run.getModSources());
+            renderUnitTestSources(run.getUnitTestSources());
+            renderClasspath(run.getClasspath());
+            renderDependencies(run.getDependencies());
+
+            outputNewLine();
+            outputNewLine();
+        }
+
+        private void renderEnvironment(Map<String, String> environment) {
+            outputIdentifier("Environment Variables:");
+            outputNewLine();
+
+            if (environment.isEmpty()) {
+                outputNormal("  - No Environment Variables");
+                outputNewLine();
+            } else {
+                environment.forEach((key, value) -> {
+                    outputIdentifier("  - " + key + ":");
+                    outputNormal(value);
+                    outputNewLine();
+                });
+            }
+        }
+
+        private void renderProperties(Map<String, String> properties) {
+            outputIdentifier("System Properties:");
+            outputNewLine();
+
+            if (properties.isEmpty()) {
+                outputNormal("  - No System Properties");
+                outputNewLine();
+            } else {
+                properties.forEach((key, value) -> {
+                    outputIdentifier("  - " + key + ":");
+                    outputNormal(value);
+                    outputNewLine();
+                });
+            }
+        }
+
+        private void renderProgramArguments(List<String> programArguments) {
+            outputIdentifier("Program Arguments:");
+            outputNewLine();
+
+            if (programArguments.isEmpty()) {
+                outputNormal("  - No Program Arguments");
+                outputNewLine();
+            } else {
+                programArguments.forEach(arg -> {
+                    outputNormal("  - " + arg);
+                    outputNewLine();
+                });
+            }
+        }
+
+        private void renderJvmArguments(List<String> jvmArguments) {
+            outputIdentifier("JVM Arguments:");
+            outputNewLine();
+
+            if (jvmArguments.isEmpty()) {
+                outputNormal("  - No JVM Arguments");
+                outputNewLine();
+            } else {
+                jvmArguments.forEach(arg -> {
+                    outputNormal("  - " + arg);
+                    outputNewLine();
+                });
+            }
+        }
+
+        private void renderModSources(Multimap<String, SourceSet> modSources) {
+            outputIdentifier("Mod Sources:");
+            outputNewLine();
+
+            if (modSources.isEmpty()) {
+                outputError("  - No Mod Sources");
+                outputNewLine();
+            } else {
+                modSources.keySet().forEach(projectId -> {
+                    outputIdentifier("  - " + projectId + ":");
+                    outputNewLine();
+                    final Collection<SourceSet> sourceSets = modSources.get(projectId);
+                    if (sourceSets.isEmpty()) {
+                        outputNormal("    - No Source Sets");
+                        outputNewLine();
+                    } else {
+                        sourceSets.forEach(sourceSet -> {
+                            outputNormal("    - " + sourceSet.getName());
+                            outputNewLine();
+                        });
+                    }
+                });
+            }
+        }
+
+        private void renderUnitTestSources(Multimap<String, SourceSet> unitTestSources) {
+            outputIdentifier("Unit Test Sources:");
+            outputNewLine();
+
+            if (unitTestSources.isEmpty()) {
+                outputError("  - No Unit Test Sources");
+                outputNewLine();
+            } else {
+                unitTestSources.keySet().forEach(projectId -> {
+                    outputIdentifier("  - " + projectId + ":");
+                    outputNewLine();
+                    final Collection<SourceSet> sourceSets = unitTestSources.get(projectId);
+                    if (sourceSets.isEmpty()) {
+                        outputNormal("    - No Source Sets");
+                        outputNewLine();
+                    } else {
+                        sourceSets.forEach(sourceSet -> {
+                            outputNormal("    - " + sourceSet.getName());
+                            outputNewLine();
+                        });
+                    }
+                });
+            }
+        }
+
+        private void renderClasspath(Set<String> classpath) {
+            outputIdentifier("Classpath:");
+            outputNewLine();
+
+            if (classpath.isEmpty()) {
+                outputError("  - No Classpath entries");
+                outputNewLine();
+            } else {
+                classpath.forEach(path -> {
+                    outputNormal("  - " + path);
+                    outputNewLine();
+                });
+            }
+        }
+
+        private void renderDependencies(Set<String> dependencies) {
+            outputIdentifier("Dependencies:");
+            outputNewLine();
+
+            if (dependencies.isEmpty()) {
+                outputError("  - No Dependencies");
+                outputNewLine();
+            } else {
+                dependencies.forEach(dependency -> {
+                    outputNormal("  - " + dependency);
+                    outputNewLine();
+                });
+            }
+        }
+    }
+}

--- a/common/src/main/java/net/neoforged/gradle/common/runtime/definition/CommonRuntimeDefinition.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runtime/definition/CommonRuntimeDefinition.java
@@ -156,7 +156,7 @@ public abstract class CommonRuntimeDefinition<S extends CommonRuntimeSpecificati
         final Map<String, String> runtimeInterpolationData = buildRunInterpolationData(run);
 
         final Map<String, String> workingInterpolationData = new HashMap<>(runtimeInterpolationData);
-        workingInterpolationData.put("source_roots", RunsUtil.buildGradleModClasses(run.getModSources()).get());
+        workingInterpolationData.put("source_roots", RunsUtil.buildGradleModClasses(run.getModSources().all()).get());
 
         if (run.getIsClient().get()) {
             getVersionJson().getPlatformJvmArgs().forEach(arg -> run.getJvmArguments().add(arg));

--- a/common/src/main/java/net/neoforged/gradle/common/util/SourceSetUtils.java
+++ b/common/src/main/java/net/neoforged/gradle/common/util/SourceSetUtils.java
@@ -6,6 +6,7 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -38,11 +39,15 @@ public class SourceSetUtils {
         throw new IllegalStateException("Could not find project for source set " + sourceSet.getName());
     }
     
-    public static String getModIdentifier(final SourceSet sourceSet) {
+    public static String getModIdentifier(final SourceSet sourceSet, final @Nullable Project project) {
         final RunnableSourceSet runnableSourceSet = sourceSet.getExtensions().findByType(RunnableSourceSet.class);
         if (runnableSourceSet != null)
             return runnableSourceSet.getModIdentifier().get();
-        
-        return getProject(sourceSet).getName();
+
+        if (project == null) {
+            return getProject(sourceSet).getName();
+        } else {
+            return project.getName();
+        }
     }
 }

--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/runs/run/Run.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/runs/run/Run.groovy
@@ -164,9 +164,30 @@ interface Run extends BaseDSLElement<Run>, NamedDSLElement {
      *
      * @return The source sets that are used as a mod.
      */
-    @Internal
+    @Nested
     @DSLProperty
-    abstract ListProperty<SourceSet> getModSources();
+    abstract RunSourceSets getModSources();
+
+    /**
+     * Adds a source set to the mod sources.
+     *
+     * @param sourceSet The source set to add.
+     */
+    void modSource(@NotNull final SourceSet sourceSet)
+
+    /**
+     * Adds source sets to the mod sources.
+     *
+     * @param sourceSets The source sets to add.
+     */
+    void modSources(@NotNull final SourceSet... sourceSets)
+
+    /**
+     * Adds source sets to the mod sources.
+     *
+     * @param sourceSets The source sets to add.
+     */
+    void modSources(@NotNull final Iterable<? extends SourceSet> sourceSets)
 
     /**
      * Defines the source sets that are used as a test.
@@ -178,7 +199,28 @@ interface Run extends BaseDSLElement<Run>, NamedDSLElement {
      */
     @Internal
     @DSLProperty
-    abstract ListProperty<SourceSet> getUnitTestSources();
+    abstract RunSourceSets getUnitTestSources();
+
+    /**
+     * Adds a source set to the unit test sources.
+     *
+     * @param sourceSet The source set to add.
+     */
+    void unitTestSource(@NotNull final SourceSet sourceSet)
+
+    /**
+     * Adds source sets to the unit test sources.
+     *
+     * @param sourceSets The source sets to add.
+     */
+    void unitTestSources(@NotNull final SourceSet... sourceSets)
+
+    /**
+     * Adds source sets to the unit test sources.
+     *
+     * @param sourceSets The source sets to add.
+     */
+    void unitTestSources(@NotNull final Iterable<? extends SourceSet> sourceSets)
 
     /**
      * Gives access to the classpath for this run.

--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/runs/run/RunSourceSets.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/runs/run/RunSourceSets.groovy
@@ -1,0 +1,95 @@
+package net.neoforged.gradle.dsl.common.runs.run
+
+import com.google.common.collect.Multimap
+import groovy.transform.CompileStatic
+import net.minecraftforge.gdi.ConfigurableDSLElement
+import net.minecraftforge.gdi.annotations.DSLProperty
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.SourceSet
+
+/**
+ * Represents the source sets attached to a run for a specific reason (e.g. testing, mods, etc.)
+ */
+@CompileStatic
+interface RunSourceSets extends ConfigurableDSLElement<RunSourceSets> {
+
+    /**
+     * Adds a source set to this run
+     * The group id used is derived from the project id of the source set if it is not set.
+     *
+     * @param sourceSet The source set to add
+     */
+    void add(SourceSet sourceSet);
+
+    /**
+     * Adds multiple source sets to this run
+     * The group id used is derived from the project id of the source set if it is not set.
+     *
+     * @param sourceSets The source sets to add
+     */
+    void add(Iterable<? extends SourceSet> sourceSets);
+
+    /**
+     * Adds multiple source sets to this run
+     * The group id used is derived from the project id of the source set if it is not set.
+     *
+     * @param sourceSets The source sets to add
+     */
+    void add(SourceSet... sourceSets);
+
+    /**
+     * Adds a source set to this run
+     * The group id used is derived from the local project name if it is not set.
+     *
+     * @param sourceSet The source set to add
+     */
+    void local(SourceSet sourceSet);
+
+    /**
+     * Adds multiple source sets to this run
+     * The group id used is derived from the local project name if it is not set.
+     *
+     * @param sourceSets The source sets to add
+     */
+    void local(Iterable<? extends SourceSet> sourceSets);
+
+    /**
+     * Adds multiple source sets to this run
+     * The group id used is derived from the local project name if it is not set.
+     *
+     * @param sourceSets The source sets to add
+     */
+    void local(SourceSet... sourceSets);
+
+    /**
+     * Adds a source set to this run
+     *
+     * @param groupId The group ID of the source set
+     * @param sourceSet The source set to add
+     */
+    void add(String groupId, SourceSet sourceSet);
+
+    /**
+     * Adds multiple source sets to this run
+     *
+     * @param groupId The group ID of the source sets
+     * @param sourceSets The source sets to add
+     */
+    void add(String groupId, Iterable<? extends SourceSet> sourceSets);
+
+    /**
+     * Adds multiple source sets to this run
+     *
+     * @param groupId The group ID of the source sets
+     * @param sourceSets The source sets to add
+     */
+    void add(String groupId, SourceSet... sourceSets);
+
+    /**
+     * The source sets attached to this run
+     */
+    @Internal
+    Provider<Multimap<String, SourceSet>> all();
+}

--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/util/Constants.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/util/Constants.groovy
@@ -27,7 +27,7 @@ class Constants {
     public static final String DEFAULT_PARCHMENT_GROUP = "org.parchmentmc.data"
     public static final String DEFAULT_PARCHMENT_ARTIFACT_PREFIX = "parchment-"
     public static final String DEFAULT_PARCHMENT_MAVEN_URL = "https://maven.parchmentmc.org/"
-    public static final String JST_TOOL_ARTIFACT = "net.neoforged.jst:jst-cli-bundle:1.0.36"
+    public static final String JST_TOOL_ARTIFACT = "net.neoforged.jst:jst-cli-bundle:1.0.38"
 
     public static final String DEFAULT_RECOMPILER_MAX_MEMORY = "1g"
 

--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/util/Constants.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/util/Constants.groovy
@@ -27,6 +27,7 @@ class Constants {
     public static final String DEFAULT_PARCHMENT_GROUP = "org.parchmentmc.data"
     public static final String DEFAULT_PARCHMENT_ARTIFACT_PREFIX = "parchment-"
     public static final String DEFAULT_PARCHMENT_MAVEN_URL = "https://maven.parchmentmc.org/"
+    public static final String JST_TOOL_ARTIFACT = "net.neoforged.jst:jst-cli-bundle:1.0.38"
     public static final String DEVLOGIN_TOOL_ARTIFACT = "net.covers1624:DevLogin:0.1.0.4"
     public static final String DEVLOGIN_MAIN_CLASS = "net.covers1624.devlogin.DevLogin"
 

--- a/test-utils/src/main/groovy/net/neoforged/gradle/utils/test/extensions/RuntimeBuilderExtensions.groovy
+++ b/test-utils/src/main/groovy/net/neoforged/gradle/utils/test/extensions/RuntimeBuilderExtensions.groovy
@@ -21,4 +21,26 @@ class RuntimeBuilderExtensions {
 
         return cacheDir
     }
+
+    /**
+     * Adds a manifest file to the runtime.
+     *
+     * @param self the runtime builder
+     * @param attributes the attributes to add to the manifest
+     * @return the runtime builder
+     */
+    static Runtime.Builder withManifest(final Runtime.Builder self, final Map<String, String> attributes) {
+        final String content = attributes.collect { k, v -> "$k: $v" }.join(System.lineSeparator())
+        self.file("src/main/resources/META-INF/MANIFEST.MF", content)
+    }
+
+    /**
+     * Disables conventions for the runtime.
+     *
+     * @param self the runtime builder
+     * @return the runtime builder
+     */
+    static Runtime.Builder disableConventions(final Runtime.Builder self) {
+        self.property("neogradle.subsystems.conventions.enabled", "false")
+    }
 }

--- a/userdev/src/functionalTest/groovy/net/neoforged/gradle/userdev/MultiProjectTests.groovy
+++ b/userdev/src/functionalTest/groovy/net/neoforged/gradle/userdev/MultiProjectTests.groovy
@@ -196,7 +196,7 @@ class MultiProjectTests extends BuilderBasedTestSpecification {
         run.task(':main:neoFormDecompile').outcome == TaskOutcome.SUCCESS
     }
 
-    def "multiple projects where one is not neogradle with neoforge dependencies should be able to run the game"() {
+    def "multiple projects where one is not neogradle with neoforge dependencies should pull the mod-classes entry from the project name"() {
         given:
         def rootProject = create("multi_neoforge_root_none_ng", {
             it.build("""
@@ -208,9 +208,10 @@ class MultiProjectTests extends BuilderBasedTestSpecification {
             """)
             it.withToolchains()
             it.withGlobalCacheDirectory(tempDir)
+            it.disableConventions()
         })
 
-        def apiProject = create(rootProject, "api", {
+        create(rootProject, "api", {
             it.build("""
             java {
                 toolchain {
@@ -235,7 +236,7 @@ class MultiProjectTests extends BuilderBasedTestSpecification {
             it.plugin("java-library")
         })
 
-        def mainProject = create(rootProject,"main", {
+        create(rootProject,"main", {
             it.build("""
             java {
                 toolchain {
@@ -244,15 +245,23 @@ class MultiProjectTests extends BuilderBasedTestSpecification {
             }
             
             dependencies {
-                implementation 'net.neoforged:neoforge:+'
+                implementation 'net.neoforged:neoforge:20.6.104-beta'
                 implementation project(':api')
             }
             
             runs {
                 client {
+                    modSource project.sourceSets.main
                     modSource project(':api').sourceSets.main
                 }
             }
+            """)
+            it.withManifest([
+                "FMLModType": "GAMELIBRARY",
+                "Automatic-Module-Name": "main"
+            ])
+            it.file("src/main/resources/sometime.properties", """
+                some=thing
             """)
             it.file("src/main/java/net/neoforged/gradle/main/ApiTests.java", """
                 package net.neoforged.gradle.main;
@@ -270,21 +279,353 @@ class MultiProjectTests extends BuilderBasedTestSpecification {
             it.withToolchains()
             it.withGlobalCacheDirectory(tempDir)
             it.plugin(this.pluginUnderTest)
+            it.withManifest()
         })
 
         when:
         def run = rootProject.run {
-            it.tasks(':main:runData')
-            //We are expecting this test to fail, since there is a mod without any files included so it is fine.
-            it.shouldFail()
+            it.tasks(':main:runs')
+            it.stacktrace()
         }
 
         then:
-        run.task(':main:writeMinecraftClasspathData').outcome == TaskOutcome.SUCCESS
+        run.task(':main:runs').outcome == TaskOutcome.SUCCESS
 
-        run.output.contains("Error during pre-loading phase: ERROR: File null is not a valid mod file") ||
-                run.output.contains("Caused by: net.neoforged.fml.ModLoadingException: Loading errors encountered: [\n" +
-                        "\tfml.modloading.brokenfile\n" +
-                        "]")//Validate that we are failing because of the missing mod file, and not something else.
+        def modSourcesSection = run.output.split(System.lineSeparator()).toList().subList(
+                run.output.split(System.lineSeparator()).toList().indexOf("Mod Sources:"),
+                run.output.split(System.lineSeparator()).toList().indexOf("Unit Test Sources:")
+        )
+
+        modSourcesSection.size() == 5
+        modSourcesSection.get(0) == "Mod Sources:"
+        modSourcesSection.get(1) == "  - main:"
+        modSourcesSection.get(2) == "    - main"
+        modSourcesSection.get(3) == "  - api:"
+        modSourcesSection.get(4) == "    - main"
+    }
+
+    def "multiple projects where one is not neogradle with neoforge dependencies should pull the mod-classes entry from the project name, using the dsl"() {
+        given:
+        def rootProject = create("multi_neoforge_root_none_ng", {
+            it.build("""
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(21)
+                }
+            }
+            """)
+            it.withToolchains()
+            it.withGlobalCacheDirectory(tempDir)
+            it.disableConventions()
+        })
+
+        create(rootProject, "api", {
+            it.build("""
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(21)
+                }
+            }
+            
+            dependencies {
+            }
+            """)
+            it.file("src/main/java/net/neoforged/gradle/apitest/FunctionalTests.java", """
+                package net.neoforged.gradle.apitest;
+                
+                public class FunctionalTests {
+                    public static void main(String[] args) {
+                        System.out.println("Hello World");
+                    }
+                }
+            """)
+            it.withToolchains()
+            it.withGlobalCacheDirectory(tempDir)
+            it.plugin("java-library")
+        })
+
+        create(rootProject,"main", {
+            it.build("""
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(21)
+                }
+            }
+            
+            dependencies {
+                implementation 'net.neoforged:neoforge:20.6.104-beta'
+                implementation project(':api')
+            }
+            
+            runs {
+                client {
+                    modSources {
+                       add project.sourceSets.main
+                       add project(':api').sourceSets.main
+                    }
+                }
+            }
+            """)
+            it.withManifest([
+                    "FMLModType": "GAMELIBRARY",
+                    "Automatic-Module-Name": "main"
+            ])
+            it.file("src/main/resources/sometime.properties", """
+                some=thing
+            """)
+            it.file("src/main/java/net/neoforged/gradle/main/ApiTests.java", """
+                package net.neoforged.gradle.main;
+                
+                import net.minecraft.client.Minecraft;
+                import net.neoforged.gradle.apitest.FunctionalTests;
+                
+                public class ApiTests {
+                    public static void main(String[] args) {
+                        System.out.println(Minecraft.getInstance().getClass().toString());
+                        FunctionalTests.main(args);
+                    }
+                }
+            """)
+            it.withToolchains()
+            it.withGlobalCacheDirectory(tempDir)
+            it.plugin(this.pluginUnderTest)
+            it.withManifest()
+        })
+
+        when:
+        def run = rootProject.run {
+            it.tasks(':main:runs')
+            it.stacktrace()
+        }
+
+        then:
+        run.task(':main:runs').outcome == TaskOutcome.SUCCESS
+
+        def modSourcesSection = run.output.split(System.lineSeparator()).toList().subList(
+                run.output.split(System.lineSeparator()).toList().indexOf("Mod Sources:"),
+                run.output.split(System.lineSeparator()).toList().indexOf("Unit Test Sources:")
+        )
+        modSourcesSection.size() == 5
+        modSourcesSection.get(0) == "Mod Sources:"
+        modSourcesSection.get(1) == "  - main:"
+        modSourcesSection.get(2) == "    - main"
+        modSourcesSection.get(3) == "  - api:"
+        modSourcesSection.get(4) == "    - main"
+    }
+
+    def "multiple projects where one is not neogradle with neoforge dependencies should combine the mod-classes entry from the project name, using the local-dsl"() {
+        given:
+        def rootProject = create("multi_neoforge_root_none_ng", {
+            it.build("""
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(21)
+                }
+            }
+            """)
+            it.withToolchains()
+            it.withGlobalCacheDirectory(tempDir)
+            it.disableConventions()
+        })
+
+        create(rootProject, "api", {
+            it.build("""
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(21)
+                }
+            }
+            
+            dependencies {
+            }
+            """)
+            it.file("src/main/java/net/neoforged/gradle/apitest/FunctionalTests.java", """
+                package net.neoforged.gradle.apitest;
+                
+                public class FunctionalTests {
+                    public static void main(String[] args) {
+                        System.out.println("Hello World");
+                    }
+                }
+            """)
+            it.withToolchains()
+            it.withGlobalCacheDirectory(tempDir)
+            it.plugin("java-library")
+        })
+
+        create(rootProject,"main", {
+            it.build("""
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(21)
+                }
+            }
+            
+            dependencies {
+                implementation 'net.neoforged:neoforge:20.6.104-beta'
+                implementation project(':api')
+            }
+            
+            runs {
+                client {
+                    modSources {
+                       add project.sourceSets.main
+                       local project(':api').sourceSets.main
+                    }
+                }
+            }
+            """)
+            it.withManifest([
+                    "FMLModType": "GAMELIBRARY",
+                    "Automatic-Module-Name": "main"
+            ])
+            it.file("src/main/resources/sometime.properties", """
+                some=thing
+            """)
+            it.file("src/main/java/net/neoforged/gradle/main/ApiTests.java", """
+                package net.neoforged.gradle.main;
+                
+                import net.minecraft.client.Minecraft;
+                import net.neoforged.gradle.apitest.FunctionalTests;
+                
+                public class ApiTests {
+                    public static void main(String[] args) {
+                        System.out.println(Minecraft.getInstance().getClass().toString());
+                        FunctionalTests.main(args);
+                    }
+                }
+            """)
+            it.withToolchains()
+            it.withGlobalCacheDirectory(tempDir)
+            it.plugin(this.pluginUnderTest)
+            it.withManifest()
+        })
+
+        when:
+        def run = rootProject.run {
+            it.tasks(':main:runs')
+            it.stacktrace()
+        }
+
+        then:
+        run.task(':main:runs').outcome == TaskOutcome.SUCCESS
+
+        def modSourcesSection = run.output.split(System.lineSeparator()).toList().subList(
+                run.output.split(System.lineSeparator()).toList().indexOf("Mod Sources:"),
+                run.output.split(System.lineSeparator()).toList().indexOf("Unit Test Sources:")
+        )
+        modSourcesSection.size() == 4
+        modSourcesSection.get(0) == "Mod Sources:"
+        modSourcesSection.get(1) == "  - main:"
+        modSourcesSection.get(2) == "    - main"
+        modSourcesSection.get(3) == "    - main"
+    }
+
+    def "multiple projects where one is not neogradle with neoforge dependencies should combine the mod-classes entry from the project name, using custom group id"() {
+        given:
+        def rootProject = create("multi_neoforge_root_none_ng", {
+            it.build("""
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(21)
+                }
+            }
+            """)
+            it.withToolchains()
+            it.withGlobalCacheDirectory(tempDir)
+            it.disableConventions()
+        })
+
+        create(rootProject, "api", {
+            it.build("""
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(21)
+                }
+            }
+            
+            dependencies {
+            }
+            """)
+            it.file("src/main/java/net/neoforged/gradle/apitest/FunctionalTests.java", """
+                package net.neoforged.gradle.apitest;
+                
+                public class FunctionalTests {
+                    public static void main(String[] args) {
+                        System.out.println("Hello World");
+                    }
+                }
+            """)
+            it.withToolchains()
+            it.withGlobalCacheDirectory(tempDir)
+            it.plugin("java-library")
+        })
+
+        create(rootProject,"main", {
+            it.build("""
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(21)
+                }
+            }
+            
+            dependencies {
+                implementation 'net.neoforged:neoforge:20.6.104-beta'
+                implementation project(':api')
+            }
+            
+            runs {
+                client {
+                    modSources {
+                       add('something', project.sourceSets.main)
+                       add('something', project(':api').sourceSets.main)
+                    }
+                }
+            }
+            """)
+            it.withManifest([
+                    "FMLModType": "GAMELIBRARY",
+                    "Automatic-Module-Name": "main"
+            ])
+            it.file("src/main/resources/sometime.properties", """
+                some=thing
+            """)
+            it.file("src/main/java/net/neoforged/gradle/main/ApiTests.java", """
+                package net.neoforged.gradle.main;
+                
+                import net.minecraft.client.Minecraft;
+                import net.neoforged.gradle.apitest.FunctionalTests;
+                
+                public class ApiTests {
+                    public static void main(String[] args) {
+                        System.out.println(Minecraft.getInstance().getClass().toString());
+                        FunctionalTests.main(args);
+                    }
+                }
+            """)
+            it.withToolchains()
+            it.withGlobalCacheDirectory(tempDir)
+            it.plugin(this.pluginUnderTest)
+            it.withManifest()
+        })
+
+        when:
+        def run = rootProject.run {
+            it.tasks(':main:runs')
+            it.stacktrace()
+        }
+
+        then:
+        run.task(':main:runs').outcome == TaskOutcome.SUCCESS
+
+        def modSourcesSection = run.output.split(System.lineSeparator()).toList().subList(
+                run.output.split(System.lineSeparator()).toList().indexOf("Mod Sources:"),
+                run.output.split(System.lineSeparator()).toList().indexOf("Unit Test Sources:")
+        )
+        modSourcesSection.size() == 4
+        modSourcesSection.get(0) == "Mod Sources:"
+        modSourcesSection.get(1) == "  - something:"
+        modSourcesSection.get(2) == "    - main"
+        modSourcesSection.get(3) == "    - main"
     }
 }

--- a/userdev/src/main/java/net/neoforged/gradle/userdev/runtime/extension/UserDevRuntimeExtension.java
+++ b/userdev/src/main/java/net/neoforged/gradle/userdev/runtime/extension/UserDevRuntimeExtension.java
@@ -97,7 +97,7 @@ public abstract class UserDevRuntimeExtension extends CommonRuntimeExtension<Use
         final NamedDomainObjectContainer<Run> runs = (NamedDomainObjectContainer<Run>) getProject().getExtensions().getByName(RunsConstants.Extensions.RUNS);
         ProjectUtils.afterEvaluate(spec.getProject(), () -> runs.stream()
                 .filter(run -> run.getIsJUnit().get())
-                .flatMap(run -> run.getUnitTestSources().get().stream())
+                .flatMap(run -> run.getUnitTestSources().all().get().values().stream())
                 .distinct()
                 .forEach(src -> {
                     DependencyCollector coll = spec.getProject().getObjects().dependencyCollector();


### PR DESCRIPTION
### TLDR:
- I was wrong to a certain degree. FML Screwed me over with how it deal with `MOD_CLASSES` this introduces a way for the modder to directly control the grouping on the runs project
- Fixes issues with unit tests
- Introduces runs reporting.
- Create unit tests to validate the grouping of sourcesets based on these run reports

### Mod SourceSet Grouping
Mod Sources and Unit Test Sources are now grouped together controllable by the runs project script via the following DSL:
```groovy
runs {
   someRun {
      modSources {
         add project.sourceSets.main // Adds the owning projects main sourceset to a group based on that sourcesets mod identifier (could be anything here, depending on the sourcesets extension values, or the project name)
         add project(':api').sourceSets.main // Assuming the API project is not using NeoGradle, this would add the api project to a group using the `api` key, because the default mod identifier for non-neogradle projects is the projects name, here api
         local project(':api').sourceSets.main // Assuming the API project is not using NeoGradle, this would add the api project to a group using the owning projects name, instead of the api projects name as a fallback (could be anything here, depending on the sourcesets extension values, or the project name)
         add('something', project(':api').sourceSets.main) // This hardcodes the group identifier to 'something', performing no lookup of the mod identifier on the sourceset, or using the owning project, or the sourcesets project.
      }
   }
}
```

### Run Reports:
A new task `runs` was added which generates a similar report to `tasks`, `configurations` and `dependencies` this allows you to debug problems with run values properly.

### Fixes:
- Bump JST to address its issues.