### PR TITLE
Rework how download locations for libraries are resolved

### DIFF
--- a/dsl/platform/src/main/groovy/net/neoforged/gradle/dsl/platform/model/InstallerProfile.groovy
+++ b/dsl/platform/src/main/groovy/net/neoforged/gradle/dsl/platform/model/InstallerProfile.groovy
@@ -182,8 +182,7 @@ abstract class InstallerProfile implements ConfigurableDSLElement<InstallerProfi
                 .withType(MavenArtifactRepository).stream().map { it.url }.collect(Collectors.toList())
         var logger = project.logger
 
-        // We use a property because it is *not* re-evaluated when queried once, while a provider
-        // is non-caching
+        // We use a property because it is *not* re-evaluated when queried, while a normal provider is
         var property = project.objects.setProperty(Library.class)
         property.set(toolConfiguration.flatMap { config ->
             logger.info("Finding download URLs for tool $tool and dependencies")

--- a/dsl/platform/src/main/groovy/net/neoforged/gradle/dsl/platform/util/LibraryCollector.groovy
+++ b/dsl/platform/src/main/groovy/net/neoforged/gradle/dsl/platform/util/LibraryCollector.groovy
@@ -70,7 +70,7 @@ class LibraryCollector extends ModuleIdentificationVisitor {
         }
     }
 
-    private static String guessMavenClassifier(File file, ModuleComponentIdentifier id) {
+    static String guessMavenClassifier(File file, ModuleComponentIdentifier id) {
         var artifact = id.module
         var version = id.version
         var expectedBasename = artifact + "-" + version;

--- a/dsl/platform/src/main/groovy/net/neoforged/gradle/dsl/platform/util/LibraryCollector.groovy
+++ b/dsl/platform/src/main/groovy/net/neoforged/gradle/dsl/platform/util/LibraryCollector.groovy
@@ -48,9 +48,9 @@ class LibraryCollector extends ModuleIdentificationVisitor {
         repositoryUrls.add(0, NEOFORGED_MAVEN)
         repositoryUrls.add(0, MOJANG_MAVEN)
 
-        logger.lifecycle("Collecting libraries from:")
+        logger.info("Collecting libraries from:")
         for (var repo in repositoryUrls) {
-            logger.lifecycle(" - $repo")
+            logger.info(" - $repo")
         }
     }
 
@@ -127,7 +127,7 @@ class LibraryCollector extends ModuleIdentificationVisitor {
                                 }
                                 throw new RuntimeException(message)
                             }
-                            logger.lifecycle("  Found $name -> $artifactUri")
+                            logger.info("  Found $name -> $artifactUri")
                             artifact.getUrl().set(artifactUri.toString());
                             library
                         }
@@ -163,7 +163,7 @@ class LibraryCollector extends ModuleIdentificationVisitor {
         var result = libraries.collect {
             it.get()
         }
-        logger.lifecycle("Collected ${result.size()} libraries")
+        logger.info("Collected ${result.size()} libraries")
         return new HashSet<>(result)
     }
 }

--- a/platform/src/main/java/net/neoforged/gradle/platform/extensions/DynamicProjectExtension.java
+++ b/platform/src/main/java/net/neoforged/gradle/platform/extensions/DynamicProjectExtension.java
@@ -392,9 +392,8 @@ public abstract class DynamicProjectExtension implements BaseDSLElement<DynamicP
                 profile.data("MC_SRG", String.format("[net.minecraft:client:%s:srg]", neoFormVersion), String.format("[net.minecraft:server:%s:srg]", neoFormVersion));
                 profile.data("PATCHED", String.format("[%s:%s:%s:client]", "net.neoforged", "neoforge", project.getVersion()), String.format("[%s:%s:%s:server]", "net.neoforged", "neoforge", project.getVersion()));
                 profile.data("MCP_VERSION", String.format("'%s'", neoFormVersion), String.format("'%s'", neoFormVersion));
-                profile.processor(project, processor -> {
+                profile.processor(project, Constants.INSTALLERTOOLS, processor -> {
                     processor.server();
-                    processor.getJar().set(Constants.INSTALLERTOOLS);
                     processor.getArguments().addAll("--task", "EXTRACT_FILES", "--archive", "{INSTALLER}",
                             
                             "--from", "data/run.sh", "--to", "{ROOT}/run.sh", "--exec", "{ROOT}/run.sh",
@@ -407,44 +406,35 @@ public abstract class DynamicProjectExtension implements BaseDSLElement<DynamicP
                             
                             "--from", "data/unix_args.txt", "--to", String.format("{ROOT}/libraries/%s/%s/%s/unix_args.txt", project.getGroup().toString().replaceAll("\\.", "/"), project.getName(), project.getVersion()));
                 });
-                profile.processor(project, processor -> {
+                profile.processor(project, Constants.INSTALLERTOOLS, processor -> {
                     processor.server();
-                    processor.getJar().set(Constants.INSTALLERTOOLS);
                     processor.getArguments().addAll("--task", "BUNDLER_EXTRACT", "--input", "{MINECRAFT_JAR}", "--output", "{ROOT}/libraries/", "--libraries");
                 });
-                profile.processor(project, processor -> {
+                profile.processor(project, Constants.INSTALLERTOOLS, processor -> {
                     processor.server();
-                    processor.getJar().set(Constants.INSTALLERTOOLS);
                     processor.getArguments().addAll("--task", "BUNDLER_EXTRACT", "--input", "{MINECRAFT_JAR}", "--output", "{MC_UNPACKED}", "--jar-only");
                 });
-                profile.processor(project, processor -> {
-                    processor.getJar().set(Constants.INSTALLERTOOLS);
+                profile.processor(project, Constants.INSTALLERTOOLS, processor -> {
                     processor.getArguments().addAll("--task", "MCP_DATA", "--input", String.format("[%s]", neoformDependency), "--output", "{MAPPINGS}", "--key", "mappings");
                 });
-                profile.processor(project, processor -> {
-                    processor.getJar().set(Constants.INSTALLERTOOLS);
+                profile.processor(project, Constants.INSTALLERTOOLS, processor -> {
                     processor.getArguments().addAll("--task", "DOWNLOAD_MOJMAPS", "--version", runtimeDefinition.getSpecification().getMinecraftVersion(), "--side", "{SIDE}", "--output", "{MOJMAPS}");
                 });
-                profile.processor(project, processor -> {
-                    processor.getJar().set(Constants.INSTALLERTOOLS);
+                profile.processor(project, Constants.INSTALLERTOOLS, processor -> {
                     processor.getArguments().addAll("--task", "MERGE_MAPPING", "--left", "{MAPPINGS}", "--right", "{MOJMAPS}", "--output", "{MERGED_MAPPINGS}", "--classes", "--fields", "--methods", "--reverse-right");
                 });
-                profile.processor(project, processor -> {
+                profile.processor(project, Constants.JARSPLITTER, processor -> {
                     processor.client();
-                    processor.getJar().set(Constants.JARSPLITTER);
                     processor.getArguments().addAll("--input", "{MINECRAFT_JAR}", "--slim", "{MC_SLIM}", "--extra", "{MC_EXTRA}", "--srg", "{MERGED_MAPPINGS}");
                 });
-                profile.processor(project, processor -> {
+                profile.processor(project, Constants.JARSPLITTER, processor -> {
                     processor.server();
-                    processor.getJar().set(Constants.JARSPLITTER);
                     processor.getArguments().addAll("--input", "{MC_UNPACKED}", "--slim", "{MC_SLIM}", "--extra", "{MC_EXTRA}", "--srg", "{MERGED_MAPPINGS}");
                 });
-                profile.processor(project, processor -> {
-                    processor.getJar().set(Constants.FART);
+                profile.processor(project, Constants.FART, processor -> {
                     processor.getArguments().addAll("--input", "{MC_SLIM}", "--output", "{MC_SRG}", "--names", "{MERGED_MAPPINGS}", "--ann-fix", "--ids-fix", "--src-fix", "--record-fix");
                 });
-                profile.processor(project, processor -> {
-                    processor.getJar().set(Constants.BINARYPATCHER);
+                profile.processor(project, Constants.BINARYPATCHER, processor -> {
                     processor.getArguments().addAll("--clean", "{MC_SRG}", "--output", "{PATCHED}", "--apply", "{BINPATCH}");
                 });
                 

--- a/platform/src/main/java/net/neoforged/gradle/platform/tasks/CreateLauncherJson.java
+++ b/platform/src/main/java/net/neoforged/gradle/platform/tasks/CreateLauncherJson.java
@@ -35,7 +35,8 @@ public abstract class CreateLauncherJson extends DefaultRuntime implements WithO
         
         clone.getLibraries().addAll(
                 getProviderFactory().provider(() -> {
-                    final LibraryCollector profileFiller = new LibraryCollector(getObjectFactory(), getRepositoryURLs().get());
+                    getLogger().info("Collecting libraries for Launcher Profile");
+                    final LibraryCollector profileFiller = new LibraryCollector(getObjectFactory(), getRepositoryURLs().get(), getLogger());
                     getLibraries().getAsFileTree().visit(profileFiller);
                     return profileFiller.getLibraries();
                 })

--- a/platform/src/main/java/net/neoforged/gradle/platform/tasks/CreateLegacyInstallerJson.java
+++ b/platform/src/main/java/net/neoforged/gradle/platform/tasks/CreateLegacyInstallerJson.java
@@ -31,14 +31,12 @@ public abstract class CreateLegacyInstallerJson extends DefaultRuntime implement
         
         final InstallerProfile profile = getProfile().get();
         final InstallerProfile copy = gson.fromJson(gson.toJson(profile), InstallerProfile.class);
-        
-        copy.getLibraries().addAll(
-                getProviderFactory().provider(() -> {
-                    final LibraryCollector profileFiller = new LibraryCollector(getObjectFactory(), getRepositoryURLs().get());
-                    getLibraries().getAsFileTree().visit(profileFiller);
-                    return profileFiller.getLibraries();
-                })
-        );
+
+        getLogger().info("Collecting gameplay libraries for installer");
+        var profileFiller = new LibraryCollector(getObjectFactory(), getRepositoryURLs().get(), getLogger());
+        getLibraries().getAsFileTree().visit(profileFiller);
+        copy.getLibraries().addAll(profileFiller.getLibraries());
+
         try {
             Files.write(output.toPath(), gson.toJson(copy).getBytes());
         } catch (IOException e) {


### PR DESCRIPTION
Speeds up publishing of NeoForge by:

- Greatly reducing the number of times the download location for a library is determined (via caching of Set<Library> for tool ids)
- Parallelizing the lookup of the download URL and using HTTP/2
- Utilize `Property` over `Provider` since a property caches its computed value, while a Provider does not

**Further work:**
Instead of caching on the tool-level, it should cache on the `(List<URI> repositoryUri, String path) ` level, since a transitive dependency may still be used by multiple different tools, but a download URI for it only has to be looked up once.