### PR TITLE
Fix healthy file existence check always failing

### DIFF
--- a/common/src/main/java/net/neoforged/gradle/common/caching/CentralCacheService.java
+++ b/common/src/main/java/net/neoforged/gradle/common/caching/CentralCacheService.java
@@ -325,9 +325,6 @@ public abstract class CentralCacheService implements BuildService<CentralCacheSe
 
         private HealthFileUsingFileBasedLock(File healthyFile) {
             this.healthyFile = healthyFile;
-
-            if (this.healthyFile.exists() && !this.healthyFile.delete())
-                throw new IllegalStateException("Failed to delete healthy marker file: " + this.healthyFile.getAbsolutePath());
         }
 
         @Override


### PR DESCRIPTION
`hasPreviousFailure` relies on this file existing to return `false`, so we cannot delete it in the constructor (otherwise it will never exist when `hasPreviousFailure` is called). The file will still correctly be deleted if execution of the task failed, since it is deleted in `close` if `hasFailed` is true.

This should fix an issue where the cache is always missed on Linux due to every health file lock being considered to have failed.