### PR TITLE
[FIx]: Fix AT issues and mute execute output further

### DIFF
--- a/common/src/main/java/net/neoforged/gradle/common/runtime/definition/CommonRuntimeDefinition.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runtime/definition/CommonRuntimeDefinition.java
@@ -17,6 +17,7 @@ import net.neoforged.gradle.dsl.common.util.ConfigurationUtils;
 import net.neoforged.gradle.dsl.common.util.GameArtifact;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.tasks.TaskProvider;
@@ -55,6 +56,9 @@ public abstract class CommonRuntimeDefinition<S extends CommonRuntimeSpecificati
 
     @NotNull
     private final Consumer<TaskProvider<? extends Runtime>> associatedTaskConsumer;
+
+    @NotNull
+    private final ConfigurableFileCollection allDependencies;
     
     @NotNull
     private final VersionJson versionJson;
@@ -76,6 +80,9 @@ public abstract class CommonRuntimeDefinition<S extends CommonRuntimeSpecificati
         this.minecraftDependenciesConfiguration = minecraftDependenciesConfiguration;
         this.associatedTaskConsumer = associatedTaskConsumer;
         this.versionJson = versionJson;
+
+        this.allDependencies = specification.getProject().files();
+        this.allDependencies.from(getMinecraftDependenciesConfiguration());
     }
 
     @Override
@@ -150,6 +157,12 @@ public abstract class CommonRuntimeDefinition<S extends CommonRuntimeSpecificati
     @NotNull
     public VersionJson getVersionJson() {
         return versionJson;
+    }
+
+    @NotNull
+    @Override
+    public final ConfigurableFileCollection getAllDependencies() {
+        return allDependencies;
     }
 
     public void configureRun(RunImpl run) {

--- a/common/src/main/java/net/neoforged/gradle/common/runtime/tasks/DefaultExecute.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runtime/tasks/DefaultExecute.java
@@ -35,6 +35,8 @@ public abstract class DefaultExecute extends DefaultRuntime implements Execute {
 
         getRuntimeProgramArguments().convention(getProgramArguments());
         getMultiRuntimeArguments().convention(getMultiArguments().AsMap());
+
+        getLogLevel().convention(LogLevel.ERROR);
     }
 
     @ServiceReference(CommonProjectPlugin.EXECUTE_SERVICE)

--- a/common/src/main/java/net/neoforged/gradle/common/runtime/tasks/SourceAccessTransformer.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runtime/tasks/SourceAccessTransformer.java
@@ -6,12 +6,7 @@ import net.neoforged.gradle.dsl.common.extensions.subsystems.Subsystems;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.plugins.JavaPluginExtension;
-import org.gradle.api.tasks.CacheableTask;
-import org.gradle.api.tasks.InputFile;
-import org.gradle.api.tasks.InputFiles;
-import org.gradle.api.tasks.PathSensitive;
-import org.gradle.api.tasks.PathSensitivity;
-import org.gradle.api.tasks.SkipWhenEmpty;
+import org.gradle.api.tasks.*;
 
 import java.io.File;
 import java.util.List;
@@ -38,6 +33,15 @@ public abstract class SourceAccessTransformer extends DefaultExecute {
 
                             args.add("--libraries-list=" + getLibraries().get().getAsFile().getAbsolutePath());
 
+                            final StringBuilder builder = new StringBuilder();
+                            getClasspath().forEach(f -> {
+                                if (!builder.isEmpty()) {
+                                    builder.append(File.pathSeparator);
+                                }
+                                builder.append(f.getAbsolutePath());
+                            });
+                            args.add("--classpath=" + builder.toString());
+
                             args.add(inputFile.getAsFile().getAbsolutePath());
                             args.add(outputFile.getAbsolutePath());
 
@@ -48,6 +52,7 @@ public abstract class SourceAccessTransformer extends DefaultExecute {
 
         getJavaVersion().convention(getProject().getExtensions().getByType(JavaPluginExtension.class).getToolchain().getLanguageVersion());
         getTransformers().finalizeValueOnRead();
+        getLogLevel().set(LogLevel.DISABLED);
     }
 
     @InputFile
@@ -57,6 +62,11 @@ public abstract class SourceAccessTransformer extends DefaultExecute {
     @InputFile
     @PathSensitive(PathSensitivity.NONE)
     public abstract RegularFileProperty getLibraries();
+
+    @InputFiles
+    @Optional
+    @PathSensitive(PathSensitivity.NONE)
+    public abstract ConfigurableFileCollection getClasspath();
 
     @InputFiles
     @SkipWhenEmpty

--- a/common/src/main/java/net/neoforged/gradle/common/util/CommonRuntimeTaskUtils.java
+++ b/common/src/main/java/net/neoforged/gradle/common/util/CommonRuntimeTaskUtils.java
@@ -8,6 +8,7 @@ import net.neoforged.gradle.dsl.common.runtime.tasks.Runtime;
 import net.neoforged.gradle.dsl.common.tasks.WithOutput;
 import net.neoforged.gradle.dsl.common.util.CommonRuntimeUtils;
 import net.neoforged.gradle.util.StringCapitalizationUtils;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.tasks.TaskProvider;
 
@@ -21,7 +22,7 @@ public final class CommonRuntimeTaskUtils {
         throw new IllegalStateException("Can not instantiate an instance of: CommonRuntimeTaskUtils. This is a utility class");
     }
 
-    public static TaskProvider<? extends SourceAccessTransformer> createSourceAccessTransformer(Definition<?> definition, String namePreFix, File workspaceDirectory, Consumer<TaskProvider<? extends Runtime>> dependentTaskConfigurationHandler, FileTree files, Collection<String> data, TaskProvider<? extends WithOutput> listLibs) {
+    public static TaskProvider<? extends SourceAccessTransformer> createSourceAccessTransformer(Definition<?> definition, String namePreFix, File workspaceDirectory, Consumer<TaskProvider<? extends Runtime>> dependentTaskConfigurationHandler, FileTree files, Collection<String> data, TaskProvider<? extends WithOutput> listLibs, FileCollection additionalClasspathElements) {
         final TaskProvider<AccessTransformerFileGenerator> generator;
         if (!data.isEmpty()) {
             generator = definition.getSpecification().getProject().getTasks().register(CommonRuntimeUtils.buildTaskName(definition.getSpecification(), namePreFix + "AccessTransformerGenerator"), AccessTransformerFileGenerator.class, task -> {
@@ -41,6 +42,7 @@ public final class CommonRuntimeTaskUtils {
             }
             task.dependsOn(listLibs);
             task.getLibraries().set(listLibs.flatMap(WithOutput::getOutput));
+            task.getClasspath().from(additionalClasspathElements);
         });
     }
 

--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/runtime/definition/Definition.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/runtime/definition/Definition.groovy
@@ -8,6 +8,8 @@ import net.neoforged.gradle.dsl.common.tasks.WithOutput
 import net.neoforged.gradle.dsl.common.util.GameArtifact
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.Dependency
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.TaskProvider
 import org.jetbrains.annotations.NotNull
 
@@ -87,4 +89,13 @@ interface Definition<S extends Specification> {
      */
     @NotNull
     abstract TaskProvider<? extends WithOutput> getListLibrariesTaskProvider();
+
+    /**
+     * Returns all the files which should be considered dependencies of the runtime.
+     * This includes the runtime's own dependencies, as well as the dependencies of the minecraft dependency.
+     *
+     * @return The dependencies of the runtime.
+     */
+    @NotNull
+    ConfigurableFileCollection getAllDependencies()
 }

--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/tasks/specifications/ExecuteSpecification.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/tasks/specifications/ExecuteSpecification.groovy
@@ -18,6 +18,11 @@ import org.gradle.api.tasks.PathSensitivity
 
 interface ExecuteSpecification extends ProjectSpecification, OutputSpecification, JavaVersionSpecification {
 
+    enum LogLevel {
+        TRACE, DEBUG, INFO, WARN, ERROR, DISABLED
+    }
+
+
     /**
      * Defines the jvm arguments in a list which are passed to the java executable.
      *
@@ -114,4 +119,8 @@ interface ExecuteSpecification extends ProjectSpecification, OutputSpecification
      */
     @Internal
     MapProperty<String, Provider<List<String>>> getMultiRuntimeArguments();
+
+    @DSLProperty
+    @Input
+    Property<LogLevel> getLogLevel();
 }

--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/util/Constants.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/util/Constants.groovy
@@ -27,7 +27,7 @@ class Constants {
     public static final String DEFAULT_PARCHMENT_GROUP = "org.parchmentmc.data"
     public static final String DEFAULT_PARCHMENT_ARTIFACT_PREFIX = "parchment-"
     public static final String DEFAULT_PARCHMENT_MAVEN_URL = "https://maven.parchmentmc.org/"
-    public static final String JST_TOOL_ARTIFACT = "net.neoforged.jst:jst-cli-bundle:1.0.38"
+    public static final String JST_TOOL_ARTIFACT = "net.neoforged.jst:jst-cli-bundle:1.0.39"
     public static final String DEVLOGIN_TOOL_ARTIFACT = "net.covers1624:DevLogin:0.1.0.4"
     public static final String DEVLOGIN_MAIN_CLASS = "net.covers1624.devlogin.DevLogin"
 

--- a/dsl/userdev/src/main/groovy/net/neoforged/gradle/dsl/userdev/runtime/specification/UserDevSpecification.groovy
+++ b/dsl/userdev/src/main/groovy/net/neoforged/gradle/dsl/userdev/runtime/specification/UserDevSpecification.groovy
@@ -1,8 +1,10 @@
 package net.neoforged.gradle.dsl.userdev.runtime.specification;
 
 import groovy.transform.CompileStatic
-import net.neoforged.gradle.dsl.common.runtime.spec.Specification;
-import org.gradle.api.provider.Provider;
+import net.neoforged.gradle.dsl.common.runtime.spec.Specification
+import net.neoforged.gradle.dsl.neoform.runtime.specification.NeoFormSpecification;
+import org.gradle.api.provider.Provider
+import org.gradle.api.specs.Spec;
 import org.jetbrains.annotations.NotNull;
 
 /**

--- a/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/definition/NeoFormRuntimeDefinition.java
+++ b/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/definition/NeoFormRuntimeDefinition.java
@@ -30,7 +30,6 @@ public class NeoFormRuntimeDefinition extends CommonRuntimeDefinition<NeoFormRun
 
     private final TaskProvider<DownloadAssets> assetsTaskProvider;
     private final TaskProvider<ExtractNatives> nativesTaskProvider;
-    private TaskProvider<? extends WithOutput> debuggingMappingsTaskProvider;
 
     public NeoFormRuntimeDefinition(@NotNull NeoFormRuntimeSpecification specification,
                                     @NotNull LinkedHashMap<String, TaskProvider<? extends WithOutput>> taskOutputs,
@@ -47,6 +46,8 @@ public class NeoFormRuntimeDefinition extends CommonRuntimeDefinition<NeoFormRun
         this.neoform = neoform;
         this.assetsTaskProvider = assetsTaskProvider;
         this.nativesTaskProvider = nativesTaskProvider;
+
+        this.getAllDependencies().from(getSpecification().getAdditionalRecompileDependencies());
     }
 
     @Override
@@ -58,10 +59,8 @@ public class NeoFormRuntimeDefinition extends CommonRuntimeDefinition<NeoFormRun
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof NeoFormRuntimeDefinition)) return false;
+        if (!(o instanceof NeoFormRuntimeDefinition that)) return false;
         if (!super.equals(o)) return false;
-
-        NeoFormRuntimeDefinition that = (NeoFormRuntimeDefinition) o;
 
         return neoform.equals(that.neoform);
     }

--- a/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/specification/NeoFormRuntimeSpecification.java
+++ b/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/specification/NeoFormRuntimeSpecification.java
@@ -77,7 +77,7 @@ public class NeoFormRuntimeSpecification extends CommonRuntimeSpecification impl
     }
 
     @Override
-    public FileCollection getAdditionalRecompileDependencies() {
+    public @NotNull FileCollection getAdditionalRecompileDependencies() {
         return additionalRecompileDependencies;
     }
 

--- a/neoform/src/main/java/net/neoforged/gradle/neoform/util/NeoFormAccessTransformerUtils.java
+++ b/neoform/src/main/java/net/neoforged/gradle/neoform/util/NeoFormAccessTransformerUtils.java
@@ -7,6 +7,7 @@ import net.neoforged.gradle.dsl.common.extensions.Minecraft;
 import net.neoforged.gradle.dsl.common.runtime.tasks.tree.TaskTreeAdapter;
 import net.neoforged.gradle.dsl.common.tasks.WithOutput;
 import org.gradle.api.Project;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.TaskProvider;
 
 public class NeoFormAccessTransformerUtils {
@@ -24,7 +25,7 @@ public class NeoFormAccessTransformerUtils {
                 return null;
             }
 
-            final TaskProvider<? extends SourceAccessTransformer> accessTransformerTask = CommonRuntimeTaskUtils.createSourceAccessTransformer(definition, "User", runtimeWorkspace, dependentTaskConfigurationHandler, accessTransformerFiles.getFiles().getAsFileTree(), accessTransformerFiles.getEntries().get(), definition.getListLibrariesTaskProvider());
+            final TaskProvider<? extends SourceAccessTransformer> accessTransformerTask = CommonRuntimeTaskUtils.createSourceAccessTransformer(definition, "User", runtimeWorkspace, dependentTaskConfigurationHandler, accessTransformerFiles.getFiles().getAsFileTree(), accessTransformerFiles.getEntries().get(), definition.getListLibrariesTaskProvider(), definition.getAllDependencies());
             accessTransformerTask.configure(task -> task.getInputFile().set(previousTasksOutput.flatMap(WithOutput::getOutput)));
             accessTransformerTask.configure(task -> task.dependsOn(previousTasksOutput));
             return accessTransformerTask;

--- a/userdev/src/main/java/net/neoforged/gradle/userdev/runtime/definition/UserDevRuntimeDefinition.java
+++ b/userdev/src/main/java/net/neoforged/gradle/userdev/runtime/definition/UserDevRuntimeDefinition.java
@@ -54,6 +54,10 @@ public final class UserDevRuntimeDefinition extends CommonRuntimeDefinition<User
         this.additionalUserDevDependencies.getDependencies().add(
                 clientExtraJar
         );
+
+        this.getAllDependencies().from(neoformRuntimeDefinition.getAllDependencies());
+        this.getAllDependencies().from(getAdditionalUserDevDependencies());
+        this.getAllDependencies().from(getUserdevConfiguration());
     }
 
     @Override

--- a/userdev/src/main/java/net/neoforged/gradle/userdev/runtime/extension/UserDevRuntimeExtension.java
+++ b/userdev/src/main/java/net/neoforged/gradle/userdev/runtime/extension/UserDevRuntimeExtension.java
@@ -129,7 +129,7 @@ public abstract class UserDevRuntimeExtension extends CommonRuntimeExtension<Use
                 userDev.matching(filter -> filter.include(accessTransformerDirectory + "/**"));
 
         return (definition, previousTasksOutput, runtimeWorkspace, gameArtifacts, mappingVersionData, dependentTaskConfigurationHandler) -> {
-            final TaskProvider<? extends SourceAccessTransformer> accessTransformerTask = CommonRuntimeTaskUtils.createSourceAccessTransformer(definition, "Forges", runtimeWorkspace, dependentTaskConfigurationHandler, accessTransformerFiles, Collections.emptyList(), definition.getListLibrariesTaskProvider());
+            final TaskProvider<? extends SourceAccessTransformer> accessTransformerTask = CommonRuntimeTaskUtils.createSourceAccessTransformer(definition, "Forges", runtimeWorkspace, dependentTaskConfigurationHandler, accessTransformerFiles, Collections.emptyList(), definition.getListLibrariesTaskProvider(), definition.getAllDependencies());
             accessTransformerTask.configure(task -> task.getInputFile().set(previousTasksOutput.flatMap(WithOutput::getOutput)));
             accessTransformerTask.configure(task -> task.dependsOn(previousTasksOutput));
             return accessTransformerTask;


### PR DESCRIPTION
This fixes the issue where the JST AT applier would not get the right classpath to analyse the source with.
Now all dependencies of a given runtime are passed in into the JST engine, including the libraries list.