### PR TITLE
Configure IDEA import only on run integration

### DIFF
--- a/common/src/main/java/net/neoforged/gradle/common/extensions/IdeManagementExtension.java
+++ b/common/src/main/java/net/neoforged/gradle/common/extensions/IdeManagementExtension.java
@@ -191,7 +191,7 @@ public abstract class IdeManagementExtension {
     public void onIdea(final IdeaIdeImportAction toPerform) {
         //When the IDEA plugin is available, configure it
         project.getPlugins().withType(IdeaExtPlugin.class, plugin -> {
-            if (!isIdeaImport()) {
+            if (!toPerform.shouldConfigureIdeaImport()) {
                 //No IDEA import even though the plugin is available, so don't configure it.
                 return;
             }
@@ -289,6 +289,13 @@ public abstract class IdeManagementExtension {
          * @param ideaExtension JetBrain's extensions to the base idea model
          */
         void idea(Project project, IdeaModel idea, ProjectSettings ideaExtension);
+
+        /**
+         * {@return whether the import action should be configured}
+         */
+        default boolean shouldConfigureIdeaImport() {
+            return Boolean.getBoolean("idea.sync.active");
+        }
     }
     
     /**

--- a/common/src/main/java/net/neoforged/gradle/common/runs/ide/IdeRunIntegrationManager.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runs/ide/IdeRunIntegrationManager.java
@@ -168,6 +168,11 @@ public class IdeRunIntegrationManager {
         }
 
         @Override
+        public boolean shouldConfigureIdeaImport() {
+            return Boolean.getBoolean("idea.active");
+        }
+
+        @Override
         public void eclipse(Project project, EclipseModel eclipse) {
             ProjectUtils.afterEvaluate(project, () -> {
                 project.getExtensions().configure(RunsConstants.Extensions.RUNS, (Action<NamedDomainObjectContainer<Run>>) runs -> runs.getAsMap().forEach((name, run) -> {


### PR DESCRIPTION
Closes #219 

Configures the IDEA import on run management such that the `RunIntegrationManager` is executed whenever any task is ran through the IDEA IDE.