### PR TITLE
Use eclipse project name rather than gradle's for vscode launch

### DIFF
--- a/common/src/main/java/net/neoforged/gradle/common/runs/ide/IdeRunIntegrationManager.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runs/ide/IdeRunIntegrationManager.java
@@ -244,7 +244,7 @@ public class IdeRunIntegrationManager {
                         .withEnvironmentVariables(adaptEnvironment(runImpl, RunsUtil::buildRunWithEclipseModClasses))
                         .withShortenCommandLine(ShortCmdBehaviour.ARGUMENT_FILE)
                         .withMainClass(runImpl.getMainClass().get())
-                        .withProjectName(project.getName())
+                        .withProjectName(eclipse.getProject().getName())
                         .withName(runName);
 
                     if (IdeManagementExtension.isVscodePluginImport(project))


### PR DESCRIPTION
Apparently eclipse generates different name than the requested via rootProject.name (and similar) if project folder name doesnt match it
_Wasn't problem back then because most of my repos are in folder of same name as rootProject.name_