### PR TITLE
Fix jarJar edge case with available-at variants

### DIFF
--- a/common/src/main/java/net/neoforged/gradle/common/dependency/JarJarArtifacts.java
+++ b/common/src/main/java/net/neoforged/gradle/common/dependency/JarJarArtifacts.java
@@ -157,13 +157,19 @@ public abstract class JarJarArtifacts {
             ComponentSelector requested = resolvedResult.getRequested();
             ResolvedVariantResult variant = resolvedResult.getResolvedVariant();
 
-            DependencyManagementObject.ArtifactIdentifier artifactIdentifier = capabilityOrModule(variant);
-            if (artifactIdentifier == null) {
-                continue;
-            }
+            List<ContainedJarIdentifier> identifiers = new ArrayList<>();
+            ResolvedVariantResult currentVariant = variant;
+            while (currentVariant != null) {
+                DependencyManagementObject.ArtifactIdentifier artifactIdentifier = capabilityOrModule(currentVariant);
+                currentVariant = currentVariant.getExternalVariant().orElse(null);
+                if (artifactIdentifier == null) {
+                    continue;
+                }
 
-            ContainedJarIdentifier jarIdentifier = new ContainedJarIdentifier(artifactIdentifier.getGroup(), artifactIdentifier.getName());
-            knownIdentifiers.add(jarIdentifier);
+                ContainedJarIdentifier jarIdentifier = new ContainedJarIdentifier(artifactIdentifier.getGroup(), artifactIdentifier.getName());
+                knownIdentifiers.add(jarIdentifier);
+                identifiers.add(jarIdentifier);
+            }
 
             String versionRange = getVersionRangeFrom(variant);
             if (versionRange == null && requested instanceof ModuleComponentSelector) {
@@ -185,10 +191,14 @@ public abstract class JarJarArtifacts {
             String version = getVersionFrom(variant);
 
             if (version != null) {
-                versions.put(jarIdentifier, version);
+                for (ContainedJarIdentifier jarIdentifier : identifiers) {
+                    versions.put(jarIdentifier, version);
+                }
             }
             if (versionRange != null) {
-                versionRanges.put(jarIdentifier, versionRange);
+                for (ContainedJarIdentifier jarIdentifier : identifiers) {
+                    versionRanges.put(jarIdentifier, versionRange);
+                }
             }
         }
     }

--- a/common/src/main/java/net/neoforged/gradle/common/dependency/JarJarArtifacts.java
+++ b/common/src/main/java/net/neoforged/gradle/common/dependency/JarJarArtifacts.java
@@ -157,6 +157,9 @@ public abstract class JarJarArtifacts {
             ComponentSelector requested = resolvedResult.getRequested();
             ResolvedVariantResult variant = resolvedResult.getResolvedVariant();
 
+            // We do this to account for any available-at usage in module metadata -- the actual artifact will only have
+            // the module ID of the final target of available-at, but the resolved dependency lets us get the whole
+            // hierarchy.
             List<ContainedJarIdentifier> identifiers = new ArrayList<>();
             ResolvedVariantResult currentVariant = variant;
             while (currentVariant != null) {


### PR DESCRIPTION
Should fix #222 -- this is a wacky edge case in how gradle's artifact resolution handles variants with their data stored in another module due to available-at directives. The variants in question are stored in jarJar metadata under the location of the module being referenced, not the referrer, because that is the capability used in gradle artifact resolution. This was tested with the repo provided in #222 and seems to resolve the issue (the dependency is properly jar-in-jar-ed).

Additionally, to make this sort of issue more visible in the future, `jarJar` will no longer "silently fail" -- for every artifact it is fed, it will either include that artifact with a version and version range, or it will throw.