### PR TITLE
Make new utilities not completely bypass capabilities

### DIFF
--- a/common/src/main/java/net/neoforged/gradle/common/extensions/sourcesets/SourceSetDependencyExtensionImpl.java
+++ b/common/src/main/java/net/neoforged/gradle/common/extensions/sourcesets/SourceSetDependencyExtensionImpl.java
@@ -43,15 +43,13 @@ public abstract class SourceSetDependencyExtensionImpl implements SourceSetDepen
         final SourceSetInheritanceExtension sourceSetInheritanceExtension = target.getExtensions().getByType(SourceSetInheritanceExtension.class);
         sourceSetInheritanceExtension.from(sourceSet);
 
-        target.setCompileClasspath(
-                target.getCompileClasspath().plus(
-                        sourceSet.getOutput()
-                )
+        project.getDependencies().add(
+                target.getCompileClasspathConfigurationName(),
+                sourceSet.getOutput()
         );
-        target.setRuntimeClasspath(
-                target.getRuntimeClasspath().plus(
-                        sourceSet.getOutput()
-                )
+        project.getDependencies().add(
+                target.getRuntimeClasspathConfigurationName(),
+                sourceSet.getOutput()
         );
     }
 }

--- a/common/src/main/java/net/neoforged/gradle/common/extensions/sourcesets/SourceSetDependencyExtensionImpl.java
+++ b/common/src/main/java/net/neoforged/gradle/common/extensions/sourcesets/SourceSetDependencyExtensionImpl.java
@@ -44,11 +44,7 @@ public abstract class SourceSetDependencyExtensionImpl implements SourceSetDepen
         sourceSetInheritanceExtension.from(sourceSet);
 
         project.getDependencies().add(
-                target.getCompileClasspathConfigurationName(),
-                sourceSet.getOutput()
-        );
-        project.getDependencies().add(
-                target.getRuntimeClasspathConfigurationName(),
+                target.getImplementationConfigurationName(),
                 sourceSet.getOutput()
         );
     }

--- a/common/src/main/java/net/neoforged/gradle/common/extensions/sourcesets/SourceSetInheritanceExtensionImpl.java
+++ b/common/src/main/java/net/neoforged/gradle/common/extensions/sourcesets/SourceSetInheritanceExtensionImpl.java
@@ -39,15 +39,11 @@ public abstract class SourceSetInheritanceExtensionImpl implements SourceSetInhe
             );
         }
 
-        target.setCompileClasspath(
-                target.getCompileClasspath().plus(
-                        sourceSet.getCompileClasspath()
-                )
+        project.getConfigurations().getByName(target.getCompileClasspathConfigurationName()).extendsFrom(
+                project.getConfigurations().getByName(sourceSet.getCompileClasspathConfigurationName())
         );
-        target.setRuntimeClasspath(
-                target.getRuntimeClasspath().plus(
-                        sourceSet.getRuntimeClasspath()
-                )
+        project.getConfigurations().getByName(target.getRuntimeClasspathConfigurationName()).extendsFrom(
+                project.getConfigurations().getByName(sourceSet.getRuntimeClasspathConfigurationName())
         );
     }
 }

--- a/userdev/src/functionalTest/groovy/net/neoforged/gradle/userdev/SourceSetTests.groovy
+++ b/userdev/src/functionalTest/groovy/net/neoforged/gradle/userdev/SourceSetTests.groovy
@@ -102,7 +102,6 @@ class SourceSetTests  extends BuilderBasedTestSpecification {
 
         then:
         run.getOutput().contains("com.google.code.gson/gson/2.11.0") || run.getOutput().contains("com.google.code.gson\\gson\\2.11.0")
-        run.getOutput().contains("inheriting_sourcesets_runtime/build/classes/java/main") || run.getOutput().contains("inheriting_sourcesets_runtime\\build\\classes\\java\\main")
     }
 
     def "depending on a sourceset adds the compile dependencies"() {


### PR DESCRIPTION
The new `inherits.from` and `depends.on` utilities completely bypass all the nice checks that gradle's dependency resolution does by just naively combining two file collections instead of going through dependency resolution. This is obviously Not Good, because it means the sort of guarantees provided by stuff like capabilities -- guarantees that mod authors like myself may be expecting consumers to be able to rely on -- just plain don't hold. This PR makes those all go through dependency resolution, as they ought to. I would highly recommend the use of feature variants and self-project-dependencies instead of `depends.on`, and the use of shared parent configurations instead of `inherits.from`, because both of those provide a mechanism to keep some dependencies internal to the inherited/depended source set, but these two utilities should at least not break the nice guarantees that gradle can provide us.