### PR TITLE
[FIX]: Fix parchment detection

### DIFF
--- a/common/src/main/java/net/neoforged/gradle/common/extensions/base/WithPropertyLookup.java
+++ b/common/src/main/java/net/neoforged/gradle/common/extensions/base/WithPropertyLookup.java
@@ -19,8 +19,11 @@ public abstract class WithPropertyLookup {
     }
 
     protected Provider<String> getStringProperty(String propertyName, String defaultValue) {
-        return this.project.getProviders().gradleProperty(SUBSYSTEM_PROPERTY_PREFIX + propertyName)
-                .orElse(defaultValue);
+        final Provider<String> property = this.project.getProviders().gradleProperty(SUBSYSTEM_PROPERTY_PREFIX + propertyName);
+        if (defaultValue == null)
+            return property;
+
+        return property.orElse(defaultValue);
     }
 
     protected Provider<Directory> getDirectoryProperty(String propertyName, Provider<Directory> defaultValue) {

--- a/common/src/main/java/net/neoforged/gradle/common/extensions/subsystems/SubsystemsExtension.java
+++ b/common/src/main/java/net/neoforged/gradle/common/extensions/subsystems/SubsystemsExtension.java
@@ -147,7 +147,7 @@ public abstract class SubsystemsExtension extends WithPropertyLookup implements 
                                                 + ":" + DEFAULT_PARCHMENT_ARTIFACT_PREFIX + minecraftVersion
                                                 + ":" + mappingVersion
                                                 + "@zip";
-                                    })
+                                    }).orElse("")
                     )
             );
             getConflictPrefix().convention("p_");

--- a/common/src/main/java/net/neoforged/gradle/common/extensions/subsystems/SubsystemsExtension.java
+++ b/common/src/main/java/net/neoforged/gradle/common/extensions/subsystems/SubsystemsExtension.java
@@ -140,7 +140,7 @@ public abstract class SubsystemsExtension extends WithPropertyLookup implements 
             super(project, "parchment");
 
             getParchmentArtifact().convention(
-                    getStringLocalProperty("parchmentArtifact", "").orElse(
+                    getStringLocalProperty("parchmentArtifact", null).orElse(
                             getMinecraftVersion()
                                     .zip(getMappingsVersion(), (minecraftVersion, mappingVersion) -> {
                                         return DEFAULT_PARCHMENT_GROUP
@@ -152,13 +152,13 @@ public abstract class SubsystemsExtension extends WithPropertyLookup implements 
             );
             getConflictPrefix().convention("p_");
             getMinecraftVersion().convention(
-                    getStringProperty("minecraftVersion", null)
+                    getStringLocalProperty("minecraftVersion", null)
             );
             getMappingsVersion().convention(
-                    getStringProperty("mappingsVersion", null)
+                    getStringLocalProperty("mappingsVersion", null)
             );
             getAddRepository().convention(
-                    getBooleanProperty("addRepository", true, false)
+                    getBooleanLocalProperty("addRepository", true)
             );
             getIsEnabled().set(getParchmentArtifact()
                     .map(s -> !s.isEmpty()).orElse(getBooleanLocalProperty("enabled", true))

--- a/userdev/src/functionalTest/groovy/net/neoforged/gradle/userdev/ParchmentTests.groovy
+++ b/userdev/src/functionalTest/groovy/net/neoforged/gradle/userdev/ParchmentTests.groovy
@@ -1,0 +1,59 @@
+package net.neoforged.gradle.userdev
+
+import net.neoforged.trainingwheels.gradle.functional.BuilderBasedTestSpecification
+import org.gradle.testkit.runner.TaskOutcome
+
+class ParchmentTests extends BuilderBasedTestSpecification {
+
+    @Override
+    protected void configurePluginUnderTest() {
+        pluginUnderTest = "net.neoforged.gradle.neoform";
+        injectIntoAllProject = true;
+    }
+
+    def "parchment can be used"() {
+        given:
+        def project = create("parchment_can_be_used", {
+            it.property("neogradle.subsystems.parchment.minecraftVersion", "1.21")
+            it.property("neogradle.subsystems.parchment.mappingsVersion", "2024.07.28")
+            it.build("""
+            plugins {
+                id 'net.neoforged.gradle.userdev'
+            }
+
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(21)
+                }
+            }
+            
+            dependencies {
+                implementation 'net.neoforged:neoforge:+'
+            }
+            """)
+            it.file("src/main/java/net/neoforged/gradle/userdev/ConfigurationCacheTests.java", """
+                package net.neoforged.gradle.userdev;
+                
+                import net.minecraft.client.Minecraft;
+                
+                public class ConfigurationCacheTests {
+                    public static void main(String[] args) {
+                        System.out.println(Minecraft.getInstance().getClass().toString());
+                    }
+                }
+            """)
+            it.withToolchains()
+            it.withGlobalCacheDirectory(tempDir)
+        })
+
+        when:
+        def run = project.run {
+            it.tasks('compileJava')
+            it.arguments('--warning-mode', 'fail', '--stacktrace')
+        }
+
+        then:
+        run.task(':compileJava').outcome == TaskOutcome.SUCCESS
+        run.task(':neoFormApplyParchment').outcome == TaskOutcome.SUCCESS
+    }
+}


### PR DESCRIPTION
Parchment detection was broken due to using an "" string checking logic combined with circular reference processing with getIsEnabled on the none local properties of the subsystem

Closes: #235 