### PR TITLE
Do not version the asset directory

### DIFF
--- a/common/src/main/java/net/neoforged/gradle/common/runtime/definition/CommonRuntimeDefinition.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runtime/definition/CommonRuntimeDefinition.java
@@ -193,7 +193,7 @@ public abstract class CommonRuntimeDefinition<S extends CommonRuntimeSpecificati
     protected void buildRunInterpolationData(RunImpl run, @NotNull MapProperty<String, String> interpolationData) {
         interpolationData.put("runtime_name", specification.getVersionedName());
         interpolationData.put("mc_version", specification.getMinecraftVersion());
-        interpolationData.put("assets_root", DownloadAssets.getAssetsDirectory(specification.getProject(), this.getVersionJson())
+        interpolationData.put("assets_root", DownloadAssets.getAssetsDirectory(specification.getProject())
                 .map(Directory::getAsFile)
                 .map(File::getAbsolutePath));
 

--- a/common/src/main/java/net/neoforged/gradle/common/runtime/tasks/DownloadAssets.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runtime/tasks/DownloadAssets.java
@@ -1,14 +1,14 @@
 package net.neoforged.gradle.common.runtime.tasks;
 
 import com.google.common.collect.Maps;
+import net.neoforged.gradle.common.runtime.tasks.action.DownloadFileAction;
 import net.neoforged.gradle.common.services.caching.CachedExecutionService;
 import net.neoforged.gradle.common.services.caching.jobs.ICacheableJob;
 import net.neoforged.gradle.common.util.FileCacheUtils;
-import net.neoforged.gradle.dsl.common.tasks.WithWorkspace;
-import net.neoforged.gradle.util.TransformerUtils;
-import net.neoforged.gradle.common.runtime.tasks.action.DownloadFileAction;
 import net.neoforged.gradle.common.util.SerializationUtils;
 import net.neoforged.gradle.common.util.VersionJson;
+import net.neoforged.gradle.dsl.common.tasks.WithWorkspace;
+import net.neoforged.gradle.util.TransformerUtils;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
 import org.gradle.api.file.Directory;
@@ -35,7 +35,7 @@ public abstract class DownloadAssets extends DefaultTask implements WithWorkspac
     private final Provider<Directory> assetsObjects;
 
     public DownloadAssets() {
-        this.assetsCache = getAssetsDirectory(getProject(), getVersionJson());
+        this.assetsCache = getAssetsDirectory(getProject());
         this.assetsObjects = assetsCache.map(directory -> directory.dir("objects"));
 
         getAssetIndex().convention("asset-index");
@@ -47,8 +47,13 @@ public abstract class DownloadAssets extends DefaultTask implements WithWorkspac
         getIsOffline().convention(getProject().getGradle().getStartParameter().isOffline());
     }
 
+    public static @NotNull Provider<Directory> getAssetsDirectory(final Project project) {
+        return FileCacheUtils.getAssetsCacheDirectory(project).map(TransformerUtils.ensureExists());
+    }
+
+    @Deprecated
     public static @NotNull Provider<Directory> getAssetsDirectory(final Project project, final Provider<VersionJson> versionJsonProvider) {
-        return FileCacheUtils.getAssetsCacheDirectory(project).flatMap(assetsDir -> assetsDir.dir(versionJsonProvider.map(VersionJson::getId))).map(TransformerUtils.ensureExists());
+        return getAssetsDirectory(project);
     }
 
     protected Provider<File> getFileInAssetsDirectory(final String fileName) {

--- a/platform/src/main/java/net/neoforged/gradle/platform/extensions/DynamicProjectExtension.java
+++ b/platform/src/main/java/net/neoforged/gradle/platform/extensions/DynamicProjectExtension.java
@@ -949,7 +949,7 @@ public abstract class DynamicProjectExtension implements BaseDSLElement<DynamicP
             );
         });
 
-        Provider<String> assetsDir = DownloadAssets.getAssetsDirectory(project, runtimeDefinition.getVersionJson()).map(Directory::getAsFile).map(File::getAbsolutePath);
+        Provider<String> assetsDir = DownloadAssets.getAssetsDirectory(project).map(Directory::getAsFile).map(File::getAbsolutePath);
         Provider<String> assetIndex = runtimeDefinition.getAssets().flatMap(DownloadAssets::getAssetIndex);
 
         run.getArguments().addAll(

--- a/vanilla/src/main/java/net/neoforged/gradle/vanilla/runtime/VanillaRuntimeDefinition.java
+++ b/vanilla/src/main/java/net/neoforged/gradle/vanilla/runtime/VanillaRuntimeDefinition.java
@@ -81,7 +81,7 @@ public final class VanillaRuntimeDefinition extends CommonRuntimeDefinition<Vani
         final String runtimeVersion = this.getClass().getPackage().getImplementationVersion();
 
         interpolationData.put(InterpolationConstants.VERSION_NAME, getSpecification().getMinecraftVersion());
-        interpolationData.put(InterpolationConstants.ASSETS_ROOT, DownloadAssets.getAssetsDirectory(run.getProject(), getVersionJson()).map(Directory::getAsFile).map(File::getAbsolutePath));
+        interpolationData.put(InterpolationConstants.ASSETS_ROOT, DownloadAssets.getAssetsDirectory(run.getProject()).map(Directory::getAsFile).map(File::getAbsolutePath));
         interpolationData.put(InterpolationConstants.ASSETS_INDEX_NAME, getAssets().flatMap(DownloadAssets::getAssetIndexFile).map(RegularFile::getAsFile).map(File::getName).map(s -> s.substring(0, s.lastIndexOf('.'))));
         interpolationData.put(InterpolationConstants.AUTH_ACCESS_TOKEN, "0");
         interpolationData.put(InterpolationConstants.USER_TYPE, "legacy");


### PR DESCRIPTION
Currently assets are written to `.gradle/caches/minecraft/assets/$MCVER`. However, the asset store is content-addressed, and so can be shared across versions. We drop the version suffix from the path to allow this.

I've deprecated the old two-arg `DownloadAssets.getAssetsDirectory` method in case other plugins/buildscripts are using it, but not sure if it counts as public API, so happy to just remove if preferred.