### PR TITLE
Properly handle run template copying when one run type is copied to another.

### DIFF
--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/runs/type/RunType.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/runs/type/RunType.groovy
@@ -100,6 +100,12 @@ abstract class RunType implements ConfigurableDSLElement<RunType>, NamedDSLEleme
         other.getEnvironmentVariables().set(getEnvironmentVariables())
         other.getSystemProperties().set(getSystemProperties())
         other.getClasspath().from(getClasspath())
+
+        if (runTemplate != null && other.getRunTemplate() != null) {
+            other.getRunTemplate().configure(runTemplate)
+        } else if (runTemplate == null) {
+            other.setRunTemplate(null)
+        }
     }
 
     /**

--- a/userdev/src/functionalTest/groovy/net/neoforged/gradle/userdev/RunTests.groovy
+++ b/userdev/src/functionalTest/groovy/net/neoforged/gradle/userdev/RunTests.groovy
@@ -552,4 +552,69 @@ class RunTests extends BuilderBasedTestSpecification {
         secondSection == thirdSection
         thirdSection == firstSection
     }
+
+    def "runs use a working directory named after them by default"() {
+        given:
+        def project = create("runs_have_configurable_working_directories_with_default", {
+            it.property('neogradle.subsystems.conventions.runs.enabled', 'false')
+            it.build("""
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(21)
+                }
+            }
+            
+            repositories {
+                mavenCentral()
+            }
+            
+            dependencies {
+                implementation 'net.neoforged:neoforge:+'
+            }
+            
+            runs {
+                aClient {
+                    runType 'client'
+                }
+            
+                bClient {
+                    runType 'client'
+                }
+                
+                cClient {
+                    runType 'client'
+                    
+                    workingDirectory project.file("clientThree")                
+                }
+            }
+            
+            """)
+            it.withToolchains()
+            it.withGlobalCacheDirectory(tempDir)
+        })
+
+        when:
+        def run = project.run {
+            it.tasks(':runs')
+            it.stacktrace()
+        }
+
+        then:
+        def lines = run.getOutput().split("\n");
+        def firstRunIndex = lines.findIndexOf { line -> line.startsWith("Run: aClient")}
+        def secondRunIndex = lines.findIndexOf { line -> line.startsWith("Run: bClient")}
+        def thirdRunIndex = lines.findIndexOf { line -> line.startsWith("Run: cClient")}
+        def endIndex = lines.findIndexOf { line -> line.startsWith("BUILD SUCCESSFUL")}
+
+        def indexes = [firstRunIndex + 1, secondRunIndex + 1, thirdRunIndex + 1, endIndex]
+        indexes.sort()
+
+        def firstSection = lines[indexes[0]..indexes[1] - 2]
+        def secondSection = lines[indexes[1]..indexes[2] - 2]
+        def thirdSection = lines[indexes[2]..indexes[3] - 2]
+
+        firstSection.find { it.contains("Working Directory:") }.toString().split(":")[1].trim().endsWith("runs_have_configurable_working_directories_with_default/runs/aClient")
+        secondSection.find { it.contains("Working Directory:") }.toString().split(":")[1].trim().endsWith("runs_have_configurable_working_directories_with_default/runs/bClient")
+        thirdSection.find { it.contains("Working Directory:") }.toString().split(":")[1].trim().endsWith("runs_have_configurable_working_directories_with_default/clientThree")
+    }
 }

--- a/userdev/src/functionalTest/groovy/net/neoforged/gradle/userdev/RunTests.groovy
+++ b/userdev/src/functionalTest/groovy/net/neoforged/gradle/userdev/RunTests.groovy
@@ -613,8 +613,8 @@ class RunTests extends BuilderBasedTestSpecification {
         def secondSection = lines[indexes[1]..indexes[2] - 2]
         def thirdSection = lines[indexes[2]..indexes[3] - 2]
 
-        firstSection.find { it.contains("Working Directory:") }.toString().split(":")[1].trim().endsWith("runs_have_configurable_working_directories_with_default/runs/aClient")
-        secondSection.find { it.contains("Working Directory:") }.toString().split(":")[1].trim().endsWith("runs_have_configurable_working_directories_with_default/runs/bClient")
-        thirdSection.find { it.contains("Working Directory:") }.toString().split(":")[1].trim().endsWith("runs_have_configurable_working_directories_with_default/clientThree")
+        firstSection.find { it.contains("Working Directory:") }.toString().split(":")[1].trim().endsWith("runs_have_configurable_working_directories_with_default/runs/aClient".replace("/", File.separator))
+        secondSection.find { it.contains("Working Directory:") }.toString().split(":")[1].trim().endsWith("runs_have_configurable_working_directories_with_default/runs/bClient".replace("/", File.separator))
+        thirdSection.find { it.contains("Working Directory:") }.toString().split(":")[1].trim().endsWith("runs_have_configurable_working_directories_with_default/clientThree".replace("/", File.separator))
     }
 }

--- a/userdev/src/functionalTest/groovy/net/neoforged/gradle/userdev/RunTests.groovy
+++ b/userdev/src/functionalTest/groovy/net/neoforged/gradle/userdev/RunTests.groovy
@@ -613,8 +613,10 @@ class RunTests extends BuilderBasedTestSpecification {
         def secondSection = lines[indexes[1]..indexes[2] - 2]
         def thirdSection = lines[indexes[2]..indexes[3] - 2]
 
-        firstSection.find { it.contains("Working Directory:") }.toString().split(":")[1].trim().endsWith("runs_have_configurable_working_directories_with_default/runs/aClient".replace("/", File.separator))
-        secondSection.find { it.contains("Working Directory:") }.toString().split(":")[1].trim().endsWith("runs_have_configurable_working_directories_with_default/runs/bClient".replace("/", File.separator))
-        thirdSection.find { it.contains("Working Directory:") }.toString().split(":")[1].trim().endsWith("runs_have_configurable_working_directories_with_default/clientThree".replace("/", File.separator))
+        def prefix = "Working Directory:"
+
+        firstSection.find { it.contains(prefix) }.toString().replace(prefix, "").trim().endsWith("runs_have_configurable_working_directories_with_default/runs/aClient".replace("/", File.separator))
+        secondSection.find { it.contains(prefix) }.toString().replace(prefix, "").trim().endsWith("runs_have_configurable_working_directories_with_default/runs/bClient".replace("/", File.separator))
+        thirdSection.find { it.contains(prefix) }.toString().replace(prefix, "").trim().endsWith("runs_have_configurable_working_directories_with_default/clientThree".replace("/", File.separator))
     }
 }


### PR DESCRIPTION
This fixes an issue where the default working directory of a run was changed to the one of the template, even though a template was never created on the run type from which the working copy was cloned.

Added test to cover this behaviour.