### PR TITLE
[Fix]: Dynamic project does not properly deal with detached configurations

### DIFF
--- a/dsl/platform/src/main/groovy/net/neoforged/gradle/dsl/platform/model/InstallerProfile.groovy
+++ b/dsl/platform/src/main/groovy/net/neoforged/gradle/dsl/platform/model/InstallerProfile.groovy
@@ -143,11 +143,6 @@ abstract class InstallerProfile implements ConfigurableDSLElement<InstallerProfi
     @Optional
     abstract MapProperty<String, DataFile> getData();
 
-    /**
-     * Track which tools were already added to avoid re-resolving the download URLs for the same tool over and over.
-     */
-    private final Set<String> toolLibrariesAdded = new HashSet<>()
-
     void data(String key, @Nullable String client, @Nullable String server) {
         getData().put(key, getObjectFactory().newInstance(DataFile.class).configure { DataFile it ->
             if (client != null)

--- a/platform/src/main/java/net/neoforged/gradle/platform/extensions/DynamicProjectExtension.java
+++ b/platform/src/main/java/net/neoforged/gradle/platform/extensions/DynamicProjectExtension.java
@@ -575,6 +575,7 @@ public abstract class DynamicProjectExtension implements BaseDSLElement<DynamicP
                 CommonRuntimeExtension.configureCommonRuntimeTaskParameters(task, runtimeDefinition, workingDirectory);
             });
 
+            var projectVersion = project.getVersion().toString();
             final TaskProvider<CreateLegacyInstaller> installerJar = project.getTasks().register("legacyInstallerJar", CreateLegacyInstaller.class, task -> {
                 task.getInstallerCore().set(downloadInstaller.flatMap(WithOutput::getOutput));
                 task.getInstallerJson().set(createLegacyInstallerJson.flatMap(WithOutput::getOutput));
@@ -589,8 +590,8 @@ public abstract class DynamicProjectExtension implements BaseDSLElement<DynamicP
 
                 if (project.getProperties().containsKey("neogradle.runtime.platform.installer.debug") && Boolean.parseBoolean(project.getProperties().get("neogradle.runtime.platform.installer.debug").toString())) {
                     task.from(signUniversalJar.flatMap(WithOutput::getOutput), spec -> {
-                        spec.into(String.format("/maven/net/neoforged/neoforge/%s/", project.getVersion()));
-                        spec.rename(name -> String.format("neoforge-%s-universal.jar", project.getVersion()));
+                        spec.into(String.format("/maven/net/neoforged/neoforge/%s/", projectVersion));
+                        spec.rename(name -> String.format("neoforge-%s-universal.jar", projectVersion));
                     });
                 }
             });

--- a/platform/src/main/java/net/neoforged/gradle/platform/extensions/DynamicProjectExtension.java
+++ b/platform/src/main/java/net/neoforged/gradle/platform/extensions/DynamicProjectExtension.java
@@ -391,7 +391,7 @@ public abstract class DynamicProjectExtension implements BaseDSLElement<DynamicP
                     project.getConfigurations(),
                     "InstallerRuntimeLibraries"
             );
-            installerRuntimeLibrariesConfiguration.extendsFrom(installerConfiguration);
+            ConfigurationUtils.extendsFrom(project, installerRuntimeLibrariesConfiguration, installerConfiguration);
             installerRuntimeLibrariesConfiguration.shouldResolveConsistentlyWith(runtimeClasspath);
             
             final ListProperty<URI> repoCollection = new RepositoryCollection(project.getProviders(), project.getObjects(), project.getRepositories()).getURLs();
@@ -525,7 +525,7 @@ public abstract class DynamicProjectExtension implements BaseDSLElement<DynamicP
                     project.getConfigurations(),
                     "InstallerJsonInstallerLibraries"
             );
-            installerJsonInstallerLibrariesConfiguration.extendsFrom(installerLibrariesConfiguration);
+            ConfigurationUtils.extendsFrom(project, installerJsonInstallerLibrariesConfiguration, installerLibrariesConfiguration);
             installerJsonInstallerLibrariesConfiguration.shouldResolveConsistentlyWith(runtimeClasspath);
 
             final TaskProvider<CreateLegacyInstallerJson> createLegacyInstallerJson = project.getTasks().register("createLegacyInstallerJson", CreateLegacyInstallerJson.class, task -> {
@@ -695,27 +695,27 @@ public abstract class DynamicProjectExtension implements BaseDSLElement<DynamicP
                     project.getConfigurations(),
                     "userdevLibraries"
             );
-            userdevJsonLibrariesConfiguration.extendsFrom(
+            ConfigurationUtils.extendsFrom(project,
+                    userdevJsonLibrariesConfiguration,
                     userdevCompileOnlyConfiguration,
                     installerLibrariesConfiguration,
                     gameLayerLibraryConfiguration,
                     pluginLayerLibraryConfiguration,
-                    moduleOnlyConfiguration
-            );
+                    moduleOnlyConfiguration);
             userdevJsonLibrariesConfiguration.shouldResolveConsistentlyWith(runtimeClasspath);
 
             final Configuration userdevJsonModuleOnlyConfiguration = ConfigurationUtils.temporaryUnhandledConfiguration(
                     project.getConfigurations(),
                     "userdevModuleOnly"
             );
-            userdevJsonModuleOnlyConfiguration.extendsFrom(moduleOnlyConfiguration);
+            ConfigurationUtils.extendsFrom(project, userdevJsonModuleOnlyConfiguration, moduleOnlyConfiguration);
             userdevJsonLibrariesConfiguration.shouldResolveConsistentlyWith(runtimeClasspath);
 
             final Configuration userdevJsonUserdevTestImplementationConfiguration = ConfigurationUtils.temporaryUnhandledConfiguration(
                     project.getConfigurations(),
                     "userdevJsonUserdevTestImplementation"
             );
-            userdevJsonUserdevTestImplementationConfiguration.extendsFrom(userdevTestImplementationConfiguration);
+            ConfigurationUtils.extendsFrom(project, userdevJsonUserdevTestImplementationConfiguration, userdevTestImplementationConfiguration);
             userdevJsonUserdevTestImplementationConfiguration.shouldResolveConsistentlyWith(runtimeClasspath);
 
             final TaskProvider<CreateUserdevJson> createUserdevJson = project.getTasks().register("createUserdevJson", CreateUserdevJson.class, task -> {


### PR DESCRIPTION
In 7.0.166 we switched back to detached configurations, but I missed some extendsFrom clauses which cause issues when generating the installer, because that uses extendsFrom to resolve consistently with the runtime.

Adds a test that covers a round trip of the installer, which ensures that this can not happen again.