### PR TITLE
Fix eclipse not loading due to referencing of projects across threads in its loading and parsing thread

### DIFF
--- a/common/src/main/java/net/neoforged/gradle/common/tasks/RenderDocDownloaderTask.java
+++ b/common/src/main/java/net/neoforged/gradle/common/tasks/RenderDocDownloaderTask.java
@@ -34,8 +34,8 @@ public abstract class RenderDocDownloaderTask extends NeoGradleBase {
         if (outputRoot.exists() && outputRoot.isDirectory()) {
             final File renderDocLibraryFile = getOSSpecificRenderDocLibraryFile(outputRoot);
             if (renderDocLibraryFile.exists() && renderDocLibraryFile.isFile()) {
-                //setDidWork(false);
-                //return;
+                setDidWork(false);
+                return;
             }
         }
 


### PR DESCRIPTION
Also fixes render doc on eclipse by pre-downloading its artifact instead of depending on lazy resolve.
Additionally, configures the download renderdoc task to not run always. 