### PR TITLE
[Fix]: Properly collect all dependencies in a configuration

### DIFF
--- a/.run/Remote.run.xml
+++ b/.run/Remote.run.xml
@@ -1,0 +1,15 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Remote" type="Remote">
+    <option name="USE_SOCKET_TRANSPORT" value="true" />
+    <option name="SERVER_MODE" value="false" />
+    <option name="SHMEM_ADDRESS" />
+    <option name="HOST" value="localhost" />
+    <option name="PORT" value="5005" />
+    <option name="AUTO_RESTART" value="false" />
+    <RunnerSettings RunnerId="Debug">
+      <option name="DEBUG_PORT" value="5005" />
+      <option name="LOCAL" value="false" />
+    </RunnerSettings>
+    <method v="2" />
+  </configuration>
+</component>

--- a/common/src/main/java/net/neoforged/gradle/common/util/ConfigurationUtils.java
+++ b/common/src/main/java/net/neoforged/gradle/common/util/ConfigurationUtils.java
@@ -15,10 +15,7 @@ import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.util.internal.GUtil;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Function;
 
 public class ConfigurationUtils {
@@ -39,8 +36,8 @@ public class ConfigurationUtils {
     public static void extendsFrom(final Project project, final Configuration target, final Configuration... configurations) {
         for (Configuration configuration : configurations) {
             //We treat each configuration as a dependency collector in and of it-self, and copy the dependencies and dependency constraints to the target configuration.
-            target.getDependencies().addAllLater(project.provider(configuration::getDependencies));
-            target.getDependencyConstraints().addAllLater(project.provider(configuration::getDependencyConstraints));
+            target.getDependencies().addAllLater(project.provider(configuration::getAllDependencies));
+            target.getDependencyConstraints().addAllLater(project.provider(configuration::getAllDependencyConstraints));
         }
     }
 


### PR DESCRIPTION
When switching to detached configurations some configurations that are used as extension targets, extend other configurations themselves.

This was not taken into account and caused issues with the userdev artifact not containing all dependencies on NF.