### PR TITLE
[HotFix] Fix an issue with Gradle 8.10 and worker threads realising values on Properties

### DIFF
--- a/common/src/main/java/net/neoforged/gradle/common/runs/ide/IdeRunIntegrationManager.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runs/ide/IdeRunIntegrationManager.java
@@ -187,6 +187,15 @@ public class IdeRunIntegrationManager {
                 ideBeforeRunTask.configure(task -> copyProcessResourcesTasks.forEach(task::dependsOn));
             }
 
+            //We can eagerly initialize here, as we are in an afterEvaluate after the run configuration has happened.
+            final List<String> jvmArguments = runImpl.realiseJvmArguments();
+            final List<String> programArguments = runImpl.getArguments().get();
+            final Map<String, String> productionEnvironment = adaptEnvironment(runImpl, multimapProvider -> RunsUtil.buildRunWithIdeaModClasses(multimapProvider, RunsUtil.IdeaCompileType.Production));
+            final Map<String, String> testEnvironment = adaptEnvironment(runImpl,
+                    multimapProvider -> RunsUtil.buildRunWithIdeaModClasses(multimapProvider, RunsUtil.IdeaCompileType.Production),
+                    multimapProvider -> RunsUtil.buildRunWithIdeaModClasses(multimapProvider, RunsUtil.IdeaCompileType.Test)
+            );
+
             //Do not generate a run configuration for unit tests
             if (!runImpl.getIsJUnit().get()) {
                 ideaRuns.register(runName, Application.class, ideaRun -> {
@@ -194,10 +203,10 @@ public class IdeRunIntegrationManager {
 
                     ideaRun.setMainClass(runImpl.getMainClass().get());
                     ideaRun.setWorkingDirectory(runImpl.getWorkingDirectory().get().getAsFile().getAbsolutePath());
-                    ideaRun.setJvmArgs(RunsUtil.escapeAndJoin(RunsUtil.deduplicateElementsFollowingEachOther(runImpl.realiseJvmArguments().stream()).toList()));
+                    ideaRun.setJvmArgs(RunsUtil.escapeAndJoin(RunsUtil.deduplicateElementsFollowingEachOther(jvmArguments.stream()).toList()));
                     ideaRun.setModuleName(RunsUtil.getIntellijModuleName(run.getExtensions().getByType(IdeaRunExtension.class).getPrimarySourceSet().get()));
-                    ideaRun.setProgramParameters(RunsUtil.escapeAndJoin(RunsUtil.deduplicateElementsFollowingEachOther(runImpl.getArguments().get().stream()).toList()));
-                    ideaRun.setEnvs(adaptEnvironment(runImpl, multimapProvider -> RunsUtil.buildRunWithIdeaModClasses(multimapProvider, RunsUtil.IdeaCompileType.Production)));
+                    ideaRun.setProgramParameters(RunsUtil.escapeAndJoin(RunsUtil.deduplicateElementsFollowingEachOther(programArguments.stream()).toList()));
+                    ideaRun.setEnvs(productionEnvironment);
                     ideaRun.setShortenCommandLine(ShortenCommandLine.ARGS_FILE);
 
                     ideaRun.beforeRun(beforeRuns -> {
@@ -212,7 +221,7 @@ public class IdeRunIntegrationManager {
                 });
             } else {
                 ideaRuns.register(runName, JUnitWithBeforeRun.class, ideaRun -> {
-                    final RunsUtil.PreparedUnitTestEnvironment preparedUnitTestEnvironment = RunsUtil.prepareUnitTestEnvironment(run);
+                    final RunsUtil.PreparedUnitTestEnvironment preparedUnitTestEnvironment = RunsUtil.prepareUnitTestEnvironment(run, jvmArguments, programArguments);
 
                     ideaRun.setWorkingDirectory(runImpl.getWorkingDirectory().get().getAsFile().getAbsolutePath());
                     ideaRun.setModuleName(RunsUtil.getIntellijModuleName(run.getExtensions().getByType(IdeaRunExtension.class).getPrimarySourceSet().get()));
@@ -225,14 +234,11 @@ public class IdeRunIntegrationManager {
                     ideaRun.setCategory(runImpl.getTestScope().getCategory().getOrNull());
 
                     ideaRun.setWorkingDirectory(runImpl.getWorkingDirectory().get().getAsFile().getAbsolutePath());
-                    ideaRun.setVmParameters(RunsUtil.escapeAndJoin(runImpl.realiseJvmArguments(),
+                    ideaRun.setVmParameters(RunsUtil.escapeAndJoin(jvmArguments,
                                     "-Dfml.junit.argsfile=%s".formatted(preparedUnitTestEnvironment.programArgumentsFile().getAbsolutePath()),
                                     "@%s".formatted(preparedUnitTestEnvironment.jvmArgumentsFile().getAbsolutePath())
                     ));
-                    ideaRun.setEnvs(adaptEnvironment(runImpl,
-                            multimapProvider -> RunsUtil.buildRunWithIdeaModClasses(multimapProvider, RunsUtil.IdeaCompileType.Production),
-                            multimapProvider -> RunsUtil.buildRunWithIdeaModClasses(multimapProvider, RunsUtil.IdeaCompileType.Test))
-                    );
+                    ideaRun.setEnvs(testEnvironment);
                     ideaRun.setShortenCommandLine(ShortenCommandLine.ARGS_FILE);
 
                     ideaRun.beforeRun(beforeRuns -> {

--- a/common/src/main/java/net/neoforged/gradle/common/util/run/RunsUtil.java
+++ b/common/src/main/java/net/neoforged/gradle/common/util/run/RunsUtil.java
@@ -391,15 +391,16 @@ public class RunsUtil {
     public record PreparedUnitTestEnvironment(File programArgumentsFile, File jvmArgumentsFile) {
     }
 
-    public static PreparedUnitTestEnvironment prepareUnitTestEnvironment(Run run) {
-
+    public static PreparedUnitTestEnvironment prepareUnitTestEnvironment(Run run,
+                                                                         List<String> jvmArguments,
+                                                                         List<String> programArguments) {
         return new PreparedUnitTestEnvironment(
-                createArgsFile(run.getWorkingDirectory().file("%s_test_args.txt".formatted(run.getName())), run.getArguments()),
-                createArgsFile(run.getWorkingDirectory().file("%s_jvm_args.txt".formatted(run.getName())), run.getJvmArguments())
+                createArgsFile(run.getWorkingDirectory().file("%s_test_args.txt".formatted(run.getName())), jvmArguments),
+                createArgsFile(run.getWorkingDirectory().file("%s_jvm_args.txt".formatted(run.getName())), programArguments)
         );
     }
 
-    private static File createArgsFile(Provider<RegularFile> outputFile, ListProperty<String> inputs) {
+    private static File createArgsFile(Provider<RegularFile> outputFile, List<String> inputs) {
         final File output = outputFile.get().getAsFile();
 
         if (!output.getParentFile().exists()) {
@@ -408,7 +409,7 @@ public class RunsUtil {
             }
         }
         try {
-            final List<String> value = deduplicateElementsFollowingEachOther(inputs.get().stream()).toList();
+            final List<String> value = deduplicateElementsFollowingEachOther(inputs.stream()).toList();
             if (output.exists()) {
                 if (Files.readAllLines(output.toPath()).equals(value)) {
                     return output;
@@ -429,7 +430,11 @@ public class RunsUtil {
 
     private static void configureTestTask(Project project, TaskProvider<Test> testTaskProvider, Run run) {
         testTaskProvider.configure(testTask -> {
-            PreparedUnitTestEnvironment preparedEnvironment = prepareUnitTestEnvironment(run);
+            PreparedUnitTestEnvironment preparedEnvironment = prepareUnitTestEnvironment(
+                    run,
+                    run.getJvmArguments().get(),
+                    run.getArguments().get()
+            );
 
             addRunSourcesDependenciesToTask(testTask, run, true);
             testTask.getDependsOn().add(run.getDependsOn());


### PR DESCRIPTION
### TLDR:
When an IDEA import is ran, the runs are realised potentially on a different thread then the thread that owns a project, this causes a hard to debug error which is hidden in an IDEA warning.

By realising the properties eagerly, and capturing them in locals (Which is possible), the resulting error is not triggered.

### Further research:
- finalizeOnRead()? might help here, but it might also not as the runs where not realised on those properties before during an import.