### PR TITLE
Fix multi SDK lookup causing recursive handling of Runtime creation.

### DIFF
--- a/.github/workflows/test-prs.yml
+++ b/.github/workflows/test-prs.yml
@@ -26,6 +26,9 @@ jobs:
           fetch-depth: 1000
           fetch-tags: true
 
+      - name: Fetch tags
+        run: git fetch --tags
+
       - name: Setup JDK
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/test-prs.yml
+++ b/.github/workflows/test-prs.yml
@@ -21,10 +21,7 @@ jobs:
       tests-to-run: ${{ steps.test.outputs.tests-to-run }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1000
-          fetch-tags: true
+        uses: neoforged/actions/checkout@main
 
       - name: Fetch tags
         run: git fetch --tags
@@ -51,10 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1000
-          fetch-tags: true
+        uses: neoforged/actions/checkout@main
 
       - name: Setup JDK
         uses: actions/setup-java@v4
@@ -80,10 +74,7 @@ jobs:
         os: [ubuntu, windows, macos]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1000
-          fetch-tags: true
+        uses: neoforged/actions/checkout@main
 
       - name: Setup JDK
         uses: actions/setup-java@v4
@@ -164,7 +155,8 @@ jobs:
     needs: test
     if: always()
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout sources
+        uses: neoforged/actions/checkout@main
 
       - name: Download reports' artifacts
         uses: actions/download-artifact@v4

--- a/common/src/main/java/net/neoforged/gradle/common/runs/ide/IdeRunIntegrationManager.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runs/ide/IdeRunIntegrationManager.java
@@ -174,8 +174,8 @@ public class IdeRunIntegrationManager {
             if (!defaultRun && !run.getShouldExportToIDE().get())
                 return;
 
-            final String nameWithoutSpaces = run.getName().replace(" ", "-");
-            final String runName = StringUtils.capitalize(project.getName() + ": " + StringUtils.capitalize(nameWithoutSpaces));
+            final String ideRunName = run.getIDERunName().isPresent() ? run.getIDERunName().get() : run.getName();
+            final String runName = StringUtils.capitalize(project.getName() + ": " + StringUtils.capitalize(ideRunName));
 
             final RunImpl runImpl = (RunImpl) run;
 
@@ -295,8 +295,9 @@ public class IdeRunIntegrationManager {
                         
                         final String debugName = "Run " + runName;
                         writeLaunchToFile(project, debugName, debugRun);
-                        
-                        writeLaunchToFile(project, runName,
+
+                        final String launchCombinedName = StringUtils.capitalize(project.getName() + " - " + (run.getIDERunName().isPresent() ? run.getIDERunName().get() : run.getName()));
+                        writeLaunchToFile(project, launchCombinedName,
                                 LaunchGroup.builder()
                                         .entry(LaunchGroup.entry(gradleName)
                                                        .enabled(true)
@@ -332,8 +333,7 @@ public class IdeRunIntegrationManager {
                     if (!run.getShouldExportToIDE().get())
                         return;
 
-                    final String name = run.getName();
-                    final String runName = StringUtils.capitalize(project.getName() + " - " + StringUtils.capitalize(name.replace(" ", "-")));
+                    final String runName = StringUtils.capitalize(project.getName() + " - " + StringUtils.capitalize(run.getIDERunName().isPresent() ? run.getIDERunName().get() : run.getName()));
 
                     final RunImpl runImpl = (RunImpl) run;
                     final TaskProvider<?> ideBeforeRunTask = getOrCreateIdeBeforeRunTask(project, runImpl);

--- a/common/src/main/java/net/neoforged/gradle/common/runs/run/RunImpl.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runs/run/RunImpl.java
@@ -115,6 +115,7 @@ public abstract class RunImpl implements ConfigurableDSLElement<Run>, Run {
         );
 
         getShouldExportToIDE().convention(true);
+        getIDERunName().convention(name);
     }
 
     @Override

--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/runs/run/Run.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/runs/run/Run.groovy
@@ -235,6 +235,16 @@ interface Run extends BaseDSLElement<Run>, NamedDSLElement, RunSpecification {
     abstract Provider<Set<FileSystemLocation>> getSdkClasspathElements()
 
     /**
+     * Defines the name used by the IDE run configuration.
+     *
+     * @return The IDE run name.
+     * @implNote This is only used for IDE run configurations, and defaults to the run name if not set.
+     */
+    @DSLProperty
+    @Optional
+    abstract Property<String> getIDERunName();
+
+    /**
      * Adds a run type to this run using the run type name.
      *
      * @param runType The run type to add.

--- a/userdev/src/main/java/net/neoforged/gradle/userdev/runtime/extension/UserDevRuntimeExtension.java
+++ b/userdev/src/main/java/net/neoforged/gradle/userdev/runtime/extension/UserDevRuntimeExtension.java
@@ -39,7 +39,6 @@ public abstract class UserDevRuntimeExtension extends CommonRuntimeExtension<Use
         super(project);
     }
     
-    @SuppressWarnings("unchecked")
     @Override
     protected @NotNull UserDevRuntimeDefinition doCreate(UserDevRuntimeSpecification spec) {
         final NeoFormRuntimeExtension neoFormRuntimeExtension = getProject().getExtensions().getByType(NeoFormRuntimeExtension.class);
@@ -90,9 +89,22 @@ public abstract class UserDevRuntimeExtension extends CommonRuntimeExtension<Use
             });
         });
 
+        spec.setMinecraftVersion(neoFormRuntimeDefinition.getSpecification().getMinecraftVersion());
+
+        return new UserDevRuntimeDefinition(
+                spec,
+                neoFormRuntimeDefinition,
+                userDevJar,
+                userDevProfile,
+                userDevAdditionalDependenciesConfiguration
+        );
+    }
+
+    @Override
+    protected void afterRegistration(UserDevRuntimeDefinition runtime) {
         final RunTypeManager runTypes = getProject().getExtensions().getByType(RunTypeManager.class);
-        userDevProfile.getRunTypes().forEach((type) -> {
-            TypesUtil.registerWithPotentialPrefix(runTypes, spec.getIdentifier(), type.getName(), type::copyTo);
+        runtime.getUserdevConfiguration().getRunTypes().forEach((type) -> {
+            TypesUtil.registerWithPotentialPrefix(runTypes, runtime.getSpecification().getIdentifier(), type.getName(), type::copyTo);
         });
 
         final Conventions conventions = getProject().getExtensions().getByType(Subsystems.class).getConventions();
@@ -100,7 +112,7 @@ public abstract class UserDevRuntimeExtension extends CommonRuntimeExtension<Use
                 && conventions.getRuns().getIsEnabled().get()
                 && conventions.getRuns().getShouldDefaultRunsBeCreated().get()) {
             final RunManager runs = getProject().getExtensions().getByType(RunManager.class);
-            userDevProfile.getRunTypes().forEach(runType -> {
+            runtime.getUserdevConfiguration().getRunTypes().forEach(runType -> {
                 if (runs.getNames().contains(runType.getName())) {
                     return;
                 }
@@ -116,16 +128,7 @@ public abstract class UserDevRuntimeExtension extends CommonRuntimeExtension<Use
 
             });
         }
-        
-        spec.setMinecraftVersion(neoFormRuntimeDefinition.getSpecification().getMinecraftVersion());
 
-        return new UserDevRuntimeDefinition(
-                spec,
-                neoFormRuntimeDefinition,
-                userDevJar,
-                userDevProfile,
-                userDevAdditionalDependenciesConfiguration
-        );
     }
 
     @Override


### PR DESCRIPTION
### TLDR:
Due to how SDKs are resolved it was possible that two distinct instances of a Runtime would be created when a run type was added manually, this had no functional consequences, but people inspecting the result would see different results.
This fixes this by registering the runs from the run types after the registration of the runtime to the manager.

### IDE Display names of the runs
- It is now possible to set an IDE display name of the run.