### PR TITLE
[Fix]: Handle a concurrency case in sourceset resolution of runs

### DIFF
--- a/common/src/main/java/net/neoforged/gradle/common/runs/run/RunSourceSetsImpl.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runs/run/RunSourceSetsImpl.java
@@ -106,13 +106,9 @@ public abstract class RunSourceSetsImpl implements RunSourceSets {
         }
     }
 
-    private final ReentrantLock sourceSetProvidersLock = new ReentrantLock();
-
     @Override
     public void addAllLater(Provider<Multimap<String, SourceSet>> sourceSets) {
-        sourceSetProvidersLock.lock();
         this.sourceSetProviders.add(sourceSets);
-        sourceSetProvidersLock.unlock();
     }
 
     @DSLProperty
@@ -124,16 +120,14 @@ public abstract class RunSourceSetsImpl implements RunSourceSets {
     @Override
     public Provider<Multimap<String, SourceSet>> all() {
         //Realize all lazy source sets
-        sourceSetProvidersLock.lock();
         if (!this.sourceSetProviders.isEmpty()) {
-            for (Provider<Multimap<String, SourceSet>> sourceSetProvider : this.sourceSetProviders) {
+            final var providers = new ArrayList<>(this.sourceSetProviders);
+            this.sourceSetProviders.clear();
+            for (Provider<Multimap<String, SourceSet>> sourceSetProvider : providers) {
                 final Multimap<String, SourceSet> sourceSets = sourceSetProvider.get();
                 sourceSets.forEach(this::add);
             }
-
-            this.sourceSetProviders.clear();
         }
-        sourceSetProvidersLock.unlock();
 
         return this.project.provider(() -> this.sourceSets);
     }

--- a/common/src/main/java/net/neoforged/gradle/common/runs/run/RunSourceSetsImpl.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runs/run/RunSourceSetsImpl.java
@@ -16,6 +16,8 @@ import org.gradle.api.tasks.SourceSet;
 import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantLock;
 
 public abstract class RunSourceSetsImpl implements RunSourceSets {
 
@@ -104,9 +106,13 @@ public abstract class RunSourceSetsImpl implements RunSourceSets {
         }
     }
 
+    private final ReentrantLock sourceSetProvidersLock = new ReentrantLock();
+
     @Override
     public void addAllLater(Provider<Multimap<String, SourceSet>> sourceSets) {
+        sourceSetProvidersLock.lock();
         this.sourceSetProviders.add(sourceSets);
+        sourceSetProvidersLock.unlock();
     }
 
     @DSLProperty
@@ -118,13 +124,16 @@ public abstract class RunSourceSetsImpl implements RunSourceSets {
     @Override
     public Provider<Multimap<String, SourceSet>> all() {
         //Realize all lazy source sets
+        sourceSetProvidersLock.lock();
         if (!this.sourceSetProviders.isEmpty()) {
             for (Provider<Multimap<String, SourceSet>> sourceSetProvider : this.sourceSetProviders) {
                 final Multimap<String, SourceSet> sourceSets = sourceSetProvider.get();
                 sourceSets.forEach(this::add);
             }
+
             this.sourceSetProviders.clear();
         }
+        sourceSetProvidersLock.unlock();
 
         return this.project.provider(() -> this.sourceSets);
     }


### PR DESCRIPTION
Currently a CME is thrown under certain conditions when running on G8.13. Some resolution logic internally is now running in a multi-threaded environment.

The later clear call interfered with the resolution above, so this makes a defensive copy first. Seeming solving the issue.
This is not a full fix, but even things like locks, and synchronized seemed brittle and never fix the issue on my machine fully.
Hopefully this is a permanent fix, but it will need to be rewritten for NG8