### PR TITLE
Create support for Gradle 8.14 and the handling of Eclipse base directories.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,25 +91,7 @@ subprojects.forEach { Project subProject ->
     subProject.repositories.gradlePluginPortal()
 
     //Basic dependencies: Jetbrains Annotations, JUnit and Mockito for now.
-    subProject.dependencies.api subProject.dependencies.gradleApi()
     subProject.dependencies.api "org.jetbrains:annotations:${project.jetbrains_annotations_version}"
-    subProject.dependencies.api("net.neoforged:groovydslimprover:${project.groovy_dsl_improver_version}") {
-        capabilities {
-            requireCapability 'net.neoforged:groovydslimprover-base'
-        }
-    }
-
-    subProject.dependencies.testImplementation subProject.dependencies.gradleTestKit()
-    subProject.dependencies.testImplementation "org.junit.jupiter:junit-jupiter-api:${project.junit_version}"
-    subProject.dependencies.testImplementation "org.junit.jupiter:junit-jupiter-params:${project.junit_version}"
-    subProject.dependencies.testImplementation "org.junit.jupiter:junit-jupiter-engine:${project.junit_version}"
-    subProject.dependencies.testImplementation "org.junit.platform:junit-platform-engine:${project.junit_platform_version}"
-    subProject.dependencies.testImplementation "org.mockito:mockito-junit-jupiter:${project.mockito_version}"
-    subProject.dependencies.testImplementation "org.mockito:mockito-core:${project.mockito_version}"
-    subProject.dependencies.testImplementation "org.mockito:mockito-inline:${project.mockito_version}"
-    subProject.dependencies.testImplementation "net.neoforged.trainingwheels:base:${project.trainingwheels_version}"
-    subProject.dependencies.testImplementation "net.neoforged.trainingwheels:gradle-base:${project.trainingwheels_version}"
-    subProject.dependencies.testImplementation "net.neoforged.trainingwheels:gradle-functional:${project.trainingwheels_version}"
 
     //Exclude duplicates.
     subProject.tasks.withType(Jar).configureEach { jarTask ->
@@ -149,6 +131,25 @@ subprojects.forEach { subProject ->
         if (!evalSubProject.getPlugins().hasPlugin("java-gradle-plugin")) {
             return
         }
+
+        subProject.dependencies.api subProject.dependencies.gradleApi()
+        subProject.dependencies.api("net.neoforged:groovydslimprover:${project.groovy_dsl_improver_version}") {
+            capabilities {
+                requireCapability 'net.neoforged:groovydslimprover-base'
+            }
+        }
+
+        subProject.dependencies.testImplementation subProject.dependencies.gradleTestKit()
+        subProject.dependencies.testImplementation "org.junit.jupiter:junit-jupiter-api:${project.junit_version}"
+        subProject.dependencies.testImplementation "org.junit.jupiter:junit-jupiter-params:${project.junit_version}"
+        subProject.dependencies.testImplementation "org.junit.jupiter:junit-jupiter-engine:${project.junit_version}"
+        subProject.dependencies.testImplementation "org.junit.platform:junit-platform-engine:${project.junit_platform_version}"
+        subProject.dependencies.testImplementation "org.mockito:mockito-junit-jupiter:${project.mockito_version}"
+        subProject.dependencies.testImplementation "org.mockito:mockito-core:${project.mockito_version}"
+        subProject.dependencies.testImplementation "org.mockito:mockito-inline:${project.mockito_version}"
+        subProject.dependencies.testImplementation "net.neoforged.trainingwheels:base:${project.trainingwheels_version}"
+        subProject.dependencies.testImplementation "net.neoforged.trainingwheels:gradle-base:${project.trainingwheels_version}"
+        subProject.dependencies.testImplementation "net.neoforged.trainingwheels:gradle-functional:${project.trainingwheels_version}"
 
         //Custom source set.
         evalSubProject.sourceSets.register('functionalTest') { SourceSet sourceSet ->

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -16,6 +16,11 @@ sourceSets {
 dependencies {
     api project(':utils')
     api project(':dsl-common')
+    api (project(':eclipse')) {
+        capabilities {
+            requireCapability('net.neoforged.gradle:eclipse-impl')
+        }
+    }
 
     api "commons-io:commons-io:${project.commons_io_version}"
     api "com.google.code.gson:gson:${project.gson_version}"

--- a/common/src/main/java/net/neoforged/gradle/common/CommonProjectPlugin.java
+++ b/common/src/main/java/net/neoforged/gradle/common/CommonProjectPlugin.java
@@ -36,6 +36,7 @@ import net.neoforged.gradle.dsl.common.extensions.subsystems.Subsystems;
 import net.neoforged.gradle.dsl.common.runs.run.RunManager;
 import net.neoforged.gradle.dsl.common.runs.type.RunTypeManager;
 import net.neoforged.gradle.dsl.common.util.NamingConstants;
+import net.neoforged.gradle.eclipse.EclipseMetadataReader;
 import net.neoforged.gradle.util.UrlConstants;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -161,6 +162,9 @@ public class CommonProjectPlugin implements Plugin<Project> {
         ConventionConfigurator.configureConventions(project);
 
         project.afterEvaluate(this::applyAfterEvaluate);
+
+        //EMR Init
+        EclipseMetadataReader.init(project);
     }
 
     private void applyAfterEvaluate(final Project project) {

--- a/common/src/main/java/net/neoforged/gradle/common/util/run/RunsUtil.java
+++ b/common/src/main/java/net/neoforged/gradle/common/util/run/RunsUtil.java
@@ -13,6 +13,8 @@ import net.neoforged.gradle.dsl.common.extensions.subsystems.tools.RenderDocTool
 import net.neoforged.gradle.dsl.common.runs.idea.extensions.IdeaRunsExtension;
 import net.neoforged.gradle.dsl.common.runs.run.Run;
 import net.neoforged.gradle.dsl.common.runs.run.RunDevLoginOptions;
+import net.neoforged.gradle.eclipse.EclipseMetadataReader;
+import net.neoforged.gradle.eclipse.IPropertyDelegate;
 import net.neoforged.gradle.util.StringCapitalizationUtils;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Project;
@@ -21,7 +23,7 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.*;
 import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.plugins.JavaPluginExtension;
-import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.JavaExec;
 import org.gradle.api.tasks.SourceSet;
@@ -644,12 +646,12 @@ public class RunsUtil {
     public static Provider<String> buildRunWithEclipseModClasses(final Provider<Multimap<String, SourceSet>> compileSourceSets) {
         return buildModClasses(compileSourceSets, sourceSet -> {
             final Project project = SourceSetUtils.getProject(sourceSet);
-            final EclipseModel eclipseModel = project.getExtensions().getByType(EclipseModel.class);
+            final IPropertyDelegate<File> eclipseBaseSourceOutputDir = EclipseMetadataReader.getBaseSourceOutputDirFor(project);
 
             final File conventionsDir = new File(project.getProjectDir(), "bin");
-            eclipseModel.getClasspath().getBaseSourceOutputDir().convention(project.provider(() -> conventionsDir));
+            eclipseBaseSourceOutputDir.convention(conventionsDir);
 
-            final File parentDir = eclipseModel.getClasspath().getBaseSourceOutputDir().get();
+            final File parentDir = eclipseBaseSourceOutputDir.get();
             final File sourceSetDir = new File(parentDir, sourceSet.getName());
             return Stream.of(sourceSetDir);
         });

--- a/dsl/common/build.gradle
+++ b/dsl/common/build.gradle
@@ -11,6 +11,11 @@ dependencies {
     api "com.google.guava:guava:${project.guava_version}"
     api "com.google.code.gson:gson:${project.gson_version}"
     api "net.neoforged:groovydslimprover:${project.groovy_dsl_improver_version}"
+    api("net.neoforged:groovydslimprover:${project.groovy_dsl_improver_version}") {
+        capabilities {
+            requireCapability 'net.neoforged:groovydslimprover-base'
+        }
+    }
 
     api project(':utils')
 }

--- a/dsl/mixin/build.gradle
+++ b/dsl/mixin/build.gradle
@@ -3,9 +3,15 @@ plugins {
 }
 
 dependencies {
+    api gradleApi()
     api("org.codehaus.groovy:groovy-all:${project.groovy_version}", {
         exclude group: 'junit'
     })
     api "com.google.code.gson:gson:${project.gson_version}"
     api "net.neoforged:groovydslimprover:${project.groovy_dsl_improver_version}"
+    api("net.neoforged:groovydslimprover:${project.groovy_dsl_improver_version}") {
+        capabilities {
+            requireCapability 'net.neoforged:groovydslimprover-base'
+        }
+    }
 }

--- a/eclipse/build.gradle
+++ b/eclipse/build.gradle
@@ -1,0 +1,77 @@
+plugins {
+    id 'java-library'
+}
+
+repositories {
+    maven {
+        name 'Gradle Releases'
+        url 'https://repo.gradle.org/gradle/libs-releases/'
+    }
+}
+
+java {
+    registerFeature("gradle814") {
+        usingSourceSet(sourceSets.create("gradle814"))
+        capability(project.group, project.name + "-impl", project.version)
+    }
+    registerFeature("gradle813") {
+        usingSourceSet(sourceSets.create("gradle813"))
+        capability(project.group, project.name + "-impl", project.version)
+    }
+}
+
+dependencies {
+    gradle813CompileOnly gradleApi()
+    gradle813Api (project) {
+        capabilities {
+            requireCapability('net.neoforged.gradle:eclipse')
+        }
+    }
+
+    gradle814CompileOnly ('org.gradle.experimental:gradle-public-api:8.14') {
+        capabilities {
+            requireCapability("org.gradle.experimental:gradle-public-api-internal")
+        }
+    }
+    gradle814Api (project) {
+        capabilities {
+            requireCapability('net.neoforged.gradle:eclipse')
+        }
+    }
+}
+
+Attribute<String> GRADLE_API_VERSION_ATTRIBUTE = Attribute.of("org.gradle.plugin.api-version", String.class);
+configurations {
+    gradle813ApiElements {
+        attributes {
+            attribute(GRADLE_API_VERSION_ATTRIBUTE, "8.13")
+        }
+    }
+
+    gradle813RuntimeElements {
+        attributes {
+            attribute(GRADLE_API_VERSION_ATTRIBUTE, "8.13")
+        }
+    }
+    gradle814ApiElements {
+        attributes {
+            attribute(GRADLE_API_VERSION_ATTRIBUTE, "8.14")
+        }
+    }
+
+    gradle814RuntimeElements {
+        attributes {
+            attribute(GRADLE_API_VERSION_ATTRIBUTE, "8.14")
+        }
+    }
+}
+
+AdhocComponentWithVariants javaComponent = (AdhocComponentWithVariants) project.components.findByName("java")
+javaComponent.addVariantsFromConfiguration(configurations.gradle814ApiElements) {}
+javaComponent.addVariantsFromConfiguration(configurations.gradle814RuntimeElements) {
+    it.mapToMavenScope('runtime')
+}
+javaComponent.addVariantsFromConfiguration(configurations.gradle813ApiElements) {}
+javaComponent.addVariantsFromConfiguration(configurations.gradle813RuntimeElements) {
+    it.mapToMavenScope('runtime')
+}

--- a/eclipse/src/gradle813/java/net/neoforged/gradle/eclipse/EclipseMetadataReader.java
+++ b/eclipse/src/gradle813/java/net/neoforged/gradle/eclipse/EclipseMetadataReader.java
@@ -1,0 +1,52 @@
+package net.neoforged.gradle.eclipse;
+
+import org.gradle.api.Project;
+import org.gradle.plugins.ide.eclipse.model.EclipseModel;
+
+import java.io.File;
+
+/**
+ * Special metadata reader for Eclipse.
+ * Adapted for Gradle 13, which is as of writing the default supported Gradle version.
+ */
+public class EclipseMetadataReader
+{
+
+    /**
+     * Called during project apply of the plugin.
+     * @param project the project.
+     */
+    public static void init(Project project) {
+        project.getLogger().debug("Loading Eclipse metadata from project {} for Gradle Version 8.13", project.getName());
+    }
+
+    /**
+     * The core base source output for source sets within an eclipse project.
+     *
+     * @param project The project in which the eclipse source output is looked up for.
+     * @return The file provider that targets the output directory.
+     */
+    public static IPropertyDelegate<File> getBaseSourceOutputDirFor(Project project) {
+        final EclipseModel eclipseModel = project.getExtensions().getByType(EclipseModel.class);
+        //In gradle 14 the base source directory is a DirectoryProperty
+        return new IPropertyDelegate<File>() {
+            @Override
+            public File get()
+            {
+                return eclipseModel.getClasspath().getBaseSourceOutputDir().get();
+            }
+
+            @Override
+            public void set(final File file)
+            {
+                eclipseModel.getClasspath().getBaseSourceOutputDir().set(file);
+            }
+
+            @Override
+            public void convention(final File provider)
+            {
+                eclipseModel.getClasspath().getBaseSourceOutputDir().convention(provider);
+            }
+        };
+    }
+}

--- a/eclipse/src/gradle814/java/net/neoforged/gradle/eclipse/EclipseMetadataReader.java
+++ b/eclipse/src/gradle814/java/net/neoforged/gradle/eclipse/EclipseMetadataReader.java
@@ -1,0 +1,52 @@
+package net.neoforged.gradle.eclipse;
+
+import org.gradle.api.Project;
+import org.gradle.plugins.ide.eclipse.model.EclipseModel;
+
+import java.io.File;
+
+/**
+ * Special metadata reader for Eclipse.
+ * Adapted for Gradle 14.
+ */
+public class EclipseMetadataReader
+{
+
+    /**
+     * Called during project apply of the plugin.
+     * @param project the project.
+     */
+    public static void init(Project project) {
+        project.getLogger().debug("Loading Eclipse metadata from project {} for Gradle Version 8.14", project.getName());
+    }
+
+    /**
+     * The core base source output for source sets within an eclipse project.
+     *
+     * @param project The project in which the eclipse source output is looked up for.
+     * @return The file provider that targets the output directory.
+     */
+    public static IPropertyDelegate<File> getBaseSourceOutputDirFor(final Project project) {
+        final EclipseModel eclipseModel = project.getExtensions().getByType(EclipseModel.class);
+        //In gradle 14 the base source directory is a DirectoryProperty
+        return new IPropertyDelegate<File>() {
+            @Override
+            public File get()
+            {
+                return eclipseModel.getClasspath().getBaseSourceOutputDir().getAsFile().get();
+            }
+
+            @Override
+            public void set(final File file)
+            {
+                eclipseModel.getClasspath().getBaseSourceOutputDir().set(file);
+            }
+
+            @Override
+            public void convention(final File provider)
+            {
+                eclipseModel.getClasspath().getBaseSourceOutputDir().fileProvider(project.provider(() -> provider));
+            }
+        };
+    }
+}

--- a/eclipse/src/main/java/net/neoforged/gradle/eclipse/IPropertyDelegate.java
+++ b/eclipse/src/main/java/net/neoforged/gradle/eclipse/IPropertyDelegate.java
@@ -1,0 +1,12 @@
+package net.neoforged.gradle.eclipse;
+
+import java.io.File;
+
+public interface IPropertyDelegate<T>
+{
+    T get();
+
+    void set(T t);
+
+    void convention(T provider);
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,4 +37,4 @@ spock_version=2.1
 spock_groovy_version=3.0
 mockito_version=4.11.0
 jimfs_version=1.2
-trainingwheels_version=1.0.50
+trainingwheels_version=1.0.52

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,6 +18,7 @@ include 'neoform'
 include 'userdev'
 include 'mixin'
 include 'platform'
+include 'eclipse'
 
 subProject 'dsl-common'
 subProject 'dsl-neoform'

--- a/userdev/src/functionalTest/groovy/net/neoforged/gradle/userdev/RunTests.groovy
+++ b/userdev/src/functionalTest/groovy/net/neoforged/gradle/userdev/RunTests.groovy
@@ -56,6 +56,20 @@ class RunTests extends BuilderBasedTestSpecification {
         true
         run.task(':writeMinecraftClasspathClientData').outcome == TaskOutcome.SUCCESS
         run.output.contains("is not a valid mod file")
+
+        when:
+        def runG14 = project.run {
+            it.tasks(':runClientData')
+            //We are expecting this test to fail, since there is a mod without any files included so it is fine.
+            it.shouldFail()
+            it.stacktrace()
+            it.gradleVersion("8.14")
+        }
+
+        then:
+        true
+        run.task(':writeMinecraftClasspathClientData').outcome == TaskOutcome.SUCCESS
+        run.output.contains("is not a valid mod file")
     }
 
     def "configuring of the configurations after the dependencies block should work"() {

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -5,3 +5,7 @@ dependencies {
     api "net.minecraftforge:srgutils:${project.srgutils_version}"
     api "de.siegmar:fastcsv:${project.fastcsv_version}"
 }
+
+dependencies {
+    api gradleApi()
+}


### PR DESCRIPTION
## TLDR:
- Support for G14, but not make it mandatory.

## Changes:
- Gradle specific Eclipse module which handles the implementation for the different gradle versions.
- Check and add tests for G14 base case like running and dependency replacement