### PR TITLE
Fix tests not having the proper dependencies

### DIFF
--- a/.github/gradle/gradle.gradle
+++ b/.github/gradle/gradle.gradle
@@ -126,7 +126,8 @@ subprojects.forEach { Project subProject ->
                                 }
                             }
 
-                    tests.addAll(createTestRuns(test, testClasses))
+                    if (testClasses.size() != 0)
+                        tests.addAll(createTestRuns(test, testClasses))
                 } else {
                     //This test task is not marked as a filterable test task by our central build.gradle file.
                     //Check if it has source, if so run it, else skip it. No need to setup gradle to run nothing:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ jobs:
     uses: neoforged/actions/.github/workflows/gradle-publish.yml@main
     with:
       java: 8
-      pre_gradle_tasks: test
       gradle_tasks: publish 
     secrets:
       DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}

--- a/build.gradle
+++ b/build.gradle
@@ -131,6 +131,11 @@ subprojects.forEach { Project subProject ->
     subProject.test {
         maxParallelForks = Runtime.runtime.availableProcessors() - 1
     }
+
+    //Run task which will run the functional tests.
+    subProject.tasks.named('test').configure { it ->
+        it.extensions.add('test-source-set', subProject.sourceSets.test)
+    }
 }
 
 //Configure all the subprojects that are plugins

--- a/build.gradle
+++ b/build.gradle
@@ -92,6 +92,14 @@ subprojects.forEach { Project subProject ->
 
     //Basic dependencies: Jetbrains Annotations, JUnit and Mockito for now.
     subProject.dependencies.api "org.jetbrains:annotations:${project.jetbrains_annotations_version}"
+    subProject.dependencies.testImplementation "org.junit.jupiter:junit-jupiter-api:${project.junit_version}"
+    subProject.dependencies.testImplementation "org.junit.jupiter:junit-jupiter-params:${project.junit_version}"
+    subProject.dependencies.testImplementation "org.junit.jupiter:junit-jupiter-engine:${project.junit_version}"
+    subProject.dependencies.testImplementation "org.junit.platform:junit-platform-engine:${project.junit_platform_version}"
+    subProject.dependencies.testImplementation "org.mockito:mockito-junit-jupiter:${project.mockito_version}"
+    subProject.dependencies.testImplementation "org.mockito:mockito-core:${project.mockito_version}"
+    subProject.dependencies.testImplementation "org.mockito:mockito-inline:${project.mockito_version}"
+    subProject.dependencies.testImplementation "net.neoforged.trainingwheels:base:${project.trainingwheels_version}"
 
     //Exclude duplicates.
     subProject.tasks.withType(Jar).configureEach { jarTask ->
@@ -140,14 +148,6 @@ subprojects.forEach { subProject ->
         }
 
         subProject.dependencies.testImplementation subProject.dependencies.gradleTestKit()
-        subProject.dependencies.testImplementation "org.junit.jupiter:junit-jupiter-api:${project.junit_version}"
-        subProject.dependencies.testImplementation "org.junit.jupiter:junit-jupiter-params:${project.junit_version}"
-        subProject.dependencies.testImplementation "org.junit.jupiter:junit-jupiter-engine:${project.junit_version}"
-        subProject.dependencies.testImplementation "org.junit.platform:junit-platform-engine:${project.junit_platform_version}"
-        subProject.dependencies.testImplementation "org.mockito:mockito-junit-jupiter:${project.mockito_version}"
-        subProject.dependencies.testImplementation "org.mockito:mockito-core:${project.mockito_version}"
-        subProject.dependencies.testImplementation "org.mockito:mockito-inline:${project.mockito_version}"
-        subProject.dependencies.testImplementation "net.neoforged.trainingwheels:base:${project.trainingwheels_version}"
         subProject.dependencies.testImplementation "net.neoforged.trainingwheels:gradle-base:${project.trainingwheels_version}"
         subProject.dependencies.testImplementation "net.neoforged.trainingwheels:gradle-functional:${project.trainingwheels_version}"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -38,3 +38,5 @@ spock_groovy_version=3.0
 mockito_version=4.11.0
 jimfs_version=1.2
 trainingwheels_version=1.0.52
+
+githubCiTesting=true

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -1,11 +1,9 @@
 dependencies {
+    api gradleApi()
+
     api "com.google.code.gson:gson:${project.gson_version}"
     api "com.google.guava:guava:${project.guava_version}"
     api "commons-io:commons-io:${project.commons_io_version}"
     api "net.minecraftforge:srgutils:${project.srgutils_version}"
     api "de.siegmar:fastcsv:${project.fastcsv_version}"
-}
-
-dependencies {
-    api gradleApi()
 }


### PR DESCRIPTION
## Changes:
- Ensure that unit tests have the correct dependencies
- Make sure that unit tests are also run during PR builds, not just functional tests. 
- Don't run tests on the core publishing loop.