### PR TITLE
Remove unused Groovy dependency and update Spock version reference

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -176,7 +176,7 @@ subprojects.forEach { subProject ->
         evalSubProject.dependencies.functionalTestImplementation "org.junit.jupiter:junit-jupiter-api:${project.junit_version}"
         evalSubProject.dependencies.functionalTestImplementation "org.junit.jupiter:junit-jupiter-engine:${project.junit_version}"
         evalSubProject.dependencies.functionalTestRuntimeOnly    "org.junit.platform:junit-platform-launcher"
-        evalSubProject.dependencies.functionalTestImplementation("org.spockframework:spock-core:${project.spock_version}-groovy-${project.groovy_version}") { spec ->
+        evalSubProject.dependencies.functionalTestImplementation("org.spockframework:spock-core:${project.spock_version}-groovy-${project.spock_groovy_version}") { spec ->
             spec.exclude group: 'org.codehaus.groovy'
         }
         evalSubProject.dependencies.functionalTestImplementation "net.neoforged.trainingwheels:gradle-functional:${project.trainingwheels_version}"

--- a/dsl/common/build.gradle
+++ b/dsl/common/build.gradle
@@ -3,9 +3,6 @@ plugins {
 }
 
 dependencies {
-    api ("org.codehaus.groovy:groovy-all:${project.groovy_version}", {
-        exclude group: 'junit'
-    })
     api "commons-io:commons-io:${project.commons_io_version}"
     api "org.apache.maven:maven-artifact:${project.maven_artifact_version}"
     api "com.google.guava:guava:${project.guava_version}"

--- a/dsl/neoform/build.gradle
+++ b/dsl/neoform/build.gradle
@@ -6,9 +6,6 @@ dependencies {
     api project(':dsl-common')
     api project(':utils')
 
-    api("org.codehaus.groovy:groovy-all:${project.groovy_version}", {
-        exclude group: 'junit'
-    })
     api "com.google.code.gson:gson:${project.gson_version}"
     api "net.neoforged:groovydslimprover:${project.groovy_dsl_improver_version}"
 }

--- a/dsl/userdev/build.gradle
+++ b/dsl/userdev/build.gradle
@@ -3,9 +3,6 @@ plugins {
 }
 
 dependencies {
-    api("org.codehaus.groovy:groovy-all:${project.groovy_version}", {
-        exclude group: 'junit'
-    })
     api "com.google.code.gson:gson:${project.gson_version}"
     api "net.neoforged:groovydslimprover:${project.groovy_dsl_improver_version}"
 

--- a/dsl/vanilla/build.gradle
+++ b/dsl/vanilla/build.gradle
@@ -3,9 +3,6 @@ plugins {
 }
 
 dependencies {
-    api("org.codehaus.groovy:groovy-all:${project.groovy_version}", {
-        exclude group: 'junit'
-    })
     api "com.google.code.gson:gson:${project.gson_version}"
     api "net.neoforged:groovydslimprover:${project.groovy_dsl_improver_version}"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,6 @@ group=net.neoforged.gradle
 java_version=17
 
 #Dependency versions
-groovy_version=3.0.24
 commons_io_version=2.11.0
 commons_codec_version=1.15
 gson_version=2.9.0


### PR DESCRIPTION
This fixes the compatibility with Gradle 9+ as I accidentally left the old groovy version in the dependency tree.