### PR TITLE
Remove use of getProject from Patch failure path

### DIFF
--- a/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/tasks/Patch.java
+++ b/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/tasks/Patch.java
@@ -83,7 +83,7 @@ public abstract class Patch extends DefaultRuntime {
 
         boolean success = result.exit == 0;
         if (!success) {
-            getProject().getLogger().error("Rejects saved to: {}", rejects);
+            getLogger().error("Rejects saved to: {}", rejects);
             throw new RuntimeException("Patch failure.");
         }
 


### PR DESCRIPTION
This use seems entirely unnecessary given that the task also has a logger. It causes a configuration cache error when the task fails, instead of indicating a proper failure.