### PR TITLE
Fix offline mode support and enhance task caching mechanisms

### DIFF
--- a/common/src/main/java/net/neoforged/gradle/common/runtime/extensions/CommonRuntimeExtension.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runtime/extensions/CommonRuntimeExtension.java
@@ -15,13 +15,13 @@ import net.neoforged.gradle.dsl.common.extensions.subsystems.Recompiler;
 import net.neoforged.gradle.dsl.common.extensions.subsystems.Subsystems;
 import net.neoforged.gradle.dsl.common.runtime.extensions.CommonRuntimes;
 import net.neoforged.gradle.dsl.common.runtime.spec.Specification;
+import net.neoforged.gradle.dsl.common.runtime.tasks.AsPartOfStep;
 import net.neoforged.gradle.dsl.common.runtime.tasks.Runtime;
 import net.neoforged.gradle.dsl.common.runtime.tasks.tree.TaskCustomizer;
 import net.neoforged.gradle.dsl.common.tasks.WithOutput;
 import net.neoforged.gradle.dsl.common.util.CacheableMinecraftVersion;
 import net.neoforged.gradle.dsl.common.util.CommonRuntimeUtils;
 import net.neoforged.gradle.dsl.common.util.GameArtifact;
-import net.neoforged.gradle.util.TransformerUtils;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
@@ -73,6 +73,15 @@ public abstract class CommonRuntimeExtension<S extends CommonRuntimeSpecificatio
         runtimeTask.getJavaVersion().convention(spec.getProject().getExtensions().getByType(JavaPluginExtension.class).getToolchain().getLanguageVersion());
 
         for (TaskCustomizer<? extends Task> taskCustomizer : spec.getTaskCustomizers().get(step)) {
+            taskCustomizer.apply(runtimeTask);
+        }
+    }
+
+    public static <T extends WithOutput & Task & AsPartOfStep> void configureOutputForSimpleStepTaskParameters(T runtimeTask, String step, Specification spec, File runtimeDirectory) {
+        runtimeTask.getStepName().set(step);
+        runtimeTask.getRuntimeDirectory().set(runtimeDirectory);
+
+        for (TaskCustomizer<?> taskCustomizer : spec.getTaskCustomizers().get(step)) {
             taskCustomizer.apply(runtimeTask);
         }
     }
@@ -299,16 +308,12 @@ public abstract class CommonRuntimeExtension<S extends CommonRuntimeSpecificatio
         });
     }
 
-    protected final TaskProvider<ExtractNatives> createExtractNativesTasks(final CommonRuntimeSpecification specification, final Map<String, String> symbolicDataSources, final File runtimeDirectory, final Provider<VersionJson> versionJson) {
+    protected final TaskProvider<ExtractNatives> createExtractNativesTasks(final CommonRuntimeSpecification specification, final File runtimeDirectory, final Provider<VersionJson> versionJson) {
         return specification.getProject().getTasks().register(CommonRuntimeUtils.buildTaskName(specification, "extractNatives"), ExtractNatives.class, task -> {
             task.getVersionJson().set(versionJson);
 
-            configureCommonRuntimeTaskParameters(task, symbolicDataSources, "extractNatives", specification, runtimeDirectory);
+            configureOutputForSimpleStepTaskParameters(task, "extractNatives", specification, runtimeDirectory);
             task.getOutputDirectory().set(task.getStepsDirectory().map(dir -> dir.dir("extractNatives")));
         });
-    }
-
-    protected final TaskProvider<ExtractNatives> createExtractNativesTasks(final CommonRuntimeSpecification specification, final File runtimeDirectory, final Provider<VersionJson> versionJson) {
-        return createExtractNativesTasks(specification, Collections.emptyMap(), runtimeDirectory, versionJson);
     }
 }

--- a/common/src/main/java/net/neoforged/gradle/common/runtime/specification/CommonRuntimeSpecification.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runtime/specification/CommonRuntimeSpecification.java
@@ -6,6 +6,7 @@ import com.google.common.collect.Multimap;
 import net.neoforged.gradle.common.runtime.definition.CommonRuntimeDefinition;
 import net.neoforged.gradle.common.runtime.extensions.CommonRuntimeExtension;
 import net.neoforged.gradle.dsl.common.runtime.spec.Specification;
+import net.neoforged.gradle.dsl.common.runtime.tasks.AsPartOfStep;
 import net.neoforged.gradle.dsl.common.runtime.tasks.tree.TaskCustomizer;
 import net.neoforged.gradle.dsl.common.runtime.tasks.tree.TaskTreeAdapter;
 import net.neoforged.gradle.dsl.common.util.DistributionType;
@@ -107,7 +108,7 @@ public abstract class CommonRuntimeSpecification implements Specification {
 
     @NotNull
     @Override
-    public Multimap<String, TaskCustomizer<? extends Task>> getTaskCustomizers() {
+    public Multimap<String, TaskCustomizer<?>> getTaskCustomizers() {
         return taskCustomizers;
     }
 
@@ -228,7 +229,7 @@ public abstract class CommonRuntimeSpecification implements Specification {
 
         @Override
         @NotNull
-        public final <T extends Task> B withTaskCustomizer(final String taskTypeName, Class<T> taskType, Consumer<T> customizer) {
+        public final <T extends Task & AsPartOfStep> B withTaskCustomizer(final String taskTypeName, Class<T> taskType, Consumer<T> customizer) {
             this.taskCustomizers.put(taskTypeName, new TaskCustomizer<>(taskType, customizer));
             return getThis();
         }

--- a/common/src/main/java/net/neoforged/gradle/common/runtime/tasks/DownloadAssets.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runtime/tasks/DownloadAssets.java
@@ -3,6 +3,7 @@ package net.neoforged.gradle.common.runtime.tasks;
 import com.google.common.collect.Maps;
 import net.neoforged.gradle.common.runtime.tasks.action.DownloadFileAction;
 import net.neoforged.gradle.common.services.caching.CachedExecutionService;
+import net.neoforged.gradle.common.services.caching.hasher.TaskHashingAware;
 import net.neoforged.gradle.common.services.caching.jobs.ICacheableJob;
 import net.neoforged.gradle.common.util.FileCacheUtils;
 import net.neoforged.gradle.common.util.SerializationUtils;
@@ -25,16 +26,18 @@ import org.jetbrains.annotations.NotNull;
 import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 
-@SuppressWarnings({"UnstableApiUsage"})
 @CacheableTask
-public abstract class DownloadAssets extends DefaultTask implements WithWorkspace {
+public abstract class DownloadAssets extends DefaultTask implements WithWorkspace, TaskHashingAware
+{
 
     private final Provider<Directory> assetsCache;
     private final Provider<Directory> assetsObjects;
 
-    public DownloadAssets() {
+    public DownloadAssets()
+    {
         this.assetsCache = getAssetsDirectory(getProject());
         this.assetsObjects = assetsCache.map(directory -> directory.dir("objects"));
 
@@ -47,20 +50,32 @@ public abstract class DownloadAssets extends DefaultTask implements WithWorkspac
         getIsOffline().convention(getProject().getGradle().getStartParameter().isOffline());
     }
 
-    public static @NotNull Provider<Directory> getAssetsDirectory(final Project project) {
+    @Override
+    public Map<String, Object> getHashableProperties()
+    {
+        var properties = new HashMap<>(getInputs().getProperties());
+        properties.remove("isOffline"); //We don't care about the offline mode!
+        return properties;
+    }
+
+    public static @NotNull Provider<Directory> getAssetsDirectory(final Project project)
+    {
         return FileCacheUtils.getAssetsCacheDirectory(project).map(TransformerUtils.ensureExists());
     }
 
     @Deprecated
-    public static @NotNull Provider<Directory> getAssetsDirectory(final Project project, final Provider<VersionJson> versionJsonProvider) {
+    public static @NotNull Provider<Directory> getAssetsDirectory(final Project project, final Provider<VersionJson> versionJsonProvider)
+    {
         return getAssetsDirectory(project);
     }
 
-    protected Provider<File> getFileInAssetsDirectory(final String fileName) {
+    protected Provider<File> getFileInAssetsDirectory(final String fileName)
+    {
         return assetsObjects.map(directory -> directory.file(fileName).getAsFile());
     }
 
-    protected Provider<RegularFile> getRegularFileInAssetsDirectory(final Provider<String> fileName) {
+    protected Provider<RegularFile> getRegularFileInAssetsDirectory(final Provider<String> fileName)
+    {
         return assetsCache.flatMap(directory -> fileName.map(directory::file));
     }
 
@@ -68,19 +83,21 @@ public abstract class DownloadAssets extends DefaultTask implements WithWorkspac
     public abstract Property<CachedExecutionService> getCache();
 
     @TaskAction
-    public void run() throws IOException {
+    public void run() throws IOException
+    {
         getCache().get()
-                .cached(
-                        this,
-                        ICacheableJob.Initial.file("assetIndex", this::downloadAssetIndex, getAssetIndexFile())
-                )
-                .withStage(
-                        ICacheableJob.Initial.directory("assets", assetsObjects, this::downloadAssets)
-                )
-                .execute();
+            .cached(
+                this,
+                ICacheableJob.Initial.file("assetIndex", this::downloadAssetIndex, getAssetIndexFile())
+            )
+            .withStage(
+                ICacheableJob.Initial.directory("assets", assetsObjects, this::downloadAssets)
+            )
+            .execute();
     }
 
-    private Void downloadAssetIndex() {
+    private Void downloadAssetIndex()
+    {
         final VersionJson json = getVersionJson().get();
         final VersionJson.AssetIndex assetIndexData = json.getAssetIndex();
 
@@ -98,7 +115,8 @@ public abstract class DownloadAssets extends DefaultTask implements WithWorkspac
         return null;
     }
 
-    private Void downloadAssets() {
+    private Void downloadAssets()
+    {
         final AssetIndex assetIndex = SerializationUtils.fromJson(getAssetIndexFile().getAsFile().get(), AssetIndex.class);
 
         final WorkQueue executor = getWorkerExecutor().noIsolation();
@@ -106,8 +124,8 @@ public abstract class DownloadAssets extends DefaultTask implements WithWorkspac
         assetIndex.getObjects().values().stream().distinct().forEach((asset) -> {
             final Provider<File> assetFile = getFileInAssetsDirectory(asset.getPath());
             final Provider<String> assetUrl = getAssetRepository()
-                    .map(repo -> repo.endsWith("/") ? repo : repo + "/")
-                    .map(TransformerUtils.guard(repository -> repository + asset.getPath()));
+                .map(repo -> repo.endsWith("/") ? repo : repo + "/")
+                .map(TransformerUtils.guard(repository -> repository + asset.getPath()));
 
             executor.submit(DownloadFileAction.class, params -> {
                 params.getIsOffline().set(getIsOffline());
@@ -152,37 +170,51 @@ public abstract class DownloadAssets extends DefaultTask implements WithWorkspac
     @Input
     public abstract Property<Boolean> getIsOffline();
 
-    private static class AssetIndex {
+    private static class AssetIndex
+    {
         private Map<String, Asset> objects = Maps.newHashMap();
 
-        public Map<String, Asset> getObjects() {
+        public Map<String, Asset> getObjects()
+        {
             return objects;
         }
 
-        public void setObjects(Map<String, Asset> objects) {
+        public void setObjects(Map<String, Asset> objects)
+        {
             this.objects = objects;
         }
     }
 
-    private static class Asset {
+    private static class Asset
+    {
         private String hash;
 
-        public String getHash() {
+        public String getHash()
+        {
             return hash;
         }
 
-        public void setHash(String hash) {
+        public void setHash(String hash)
+        {
             this.hash = hash;
         }
 
-        public String getPath() {
+        public String getPath()
+        {
             return hash.substring(0, 2) + '/' + hash;
         }
 
         @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (!(o instanceof Asset)) return false;
+        public boolean equals(Object o)
+        {
+            if (this == o)
+            {
+                return true;
+            }
+            if (!(o instanceof Asset))
+            {
+                return false;
+            }
 
             Asset asset = (Asset) o;
 
@@ -190,7 +222,8 @@ public abstract class DownloadAssets extends DefaultTask implements WithWorkspac
         }
 
         @Override
-        public int hashCode() {
+        public int hashCode()
+        {
             return getHash().hashCode();
         }
     }

--- a/common/src/main/java/net/neoforged/gradle/common/runtime/tasks/ExtractNatives.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runtime/tasks/ExtractNatives.java
@@ -1,5 +1,11 @@
 package net.neoforged.gradle.common.runtime.tasks;
 
+import net.neoforged.gradle.common.services.caching.CachedExecutionService;
+import net.neoforged.gradle.common.services.caching.hasher.TaskHashingAware;
+import net.neoforged.gradle.common.services.caching.jobs.ICacheableJob;
+import net.neoforged.gradle.dsl.common.runtime.tasks.AsPartOfStep;
+import net.neoforged.gradle.dsl.common.tasks.NeoGradleBase;
+import net.neoforged.gradle.dsl.common.tasks.WithOutput;
 import net.neoforged.gradle.util.TransformerUtils;
 import net.neoforged.gradle.common.runtime.tasks.action.DownloadFileAction;
 import net.neoforged.gradle.common.runtime.tasks.action.ExtractFileAction;
@@ -9,28 +15,65 @@ import org.gradle.api.file.FileTree;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.services.ServiceReference;
 import org.gradle.api.tasks.*;
 import org.gradle.workers.WorkQueue;
 import org.gradle.workers.WorkerExecutor;
 
 import javax.inject.Inject;
 import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 @CacheableTask()
-public abstract class ExtractNatives extends DefaultRuntime {
+public abstract class ExtractNatives extends NeoGradleBase implements TaskHashingAware, WithOutput, AsPartOfStep
+{
 
     public ExtractNatives() {
+        //Sets up the base configuration for directories and outputs.
+        getStepsDirectory().convention(getRuntimeDirectory().dir("steps"));
+        getOutputDirectory().convention(getStepsDirectory().flatMap(d -> getStepName().map(d::dir)));
+
         getVersionJson().convention(getVersionJsonFile().map(TransformerUtils.guard(file -> VersionJson.get(file.getAsFile()))));
         getLibrariesDirectory().convention(getOutputDirectory().map(dir -> dir.dir("libraries")));
+        getIsOffline().convention(getProject().getGradle().getStartParameter().isOffline());
+    }
+
+    @ServiceReference(CachedExecutionService.NAME)
+    public abstract Property<CachedExecutionService> getCache();
+
+    @Override
+    public Map<String, Object> getHashableProperties()
+    {
+        var properties = new HashMap<>(getInputs().getProperties());
+        properties.remove("isOffline"); //We don't care about the offline mode!
+        return properties;
     }
 
     @TaskAction
-    public void extract() {
-        downloadNatives();
-        extractNatives();
+    public void run() throws IOException
+    {
+        getCache().get()
+            .cached(
+                this,
+                ICacheableJob.Initial.directory("nativesAndLibraries", getLibrariesDirectory(), this::doDownloadAndExtract)
+            )
+            .execute();
     }
 
-    private void downloadNatives() {
+    private File doDownloadAndExtract() {
+        downloadNatives();
+        extractNatives();
+
+        final File librariesDirectory = ensureFileWorkspaceReady(getLibrariesDirectory().get().getAsFile());
+        if (!librariesDirectory.exists())
+            librariesDirectory.mkdirs();
+
+        return librariesDirectory;
+    }
+
+    private File downloadNatives() {
         final VersionJson versionJson = getVersionJson().get();
 
         final WorkQueue executor = getWorkerExecutor().noIsolation();
@@ -39,7 +82,7 @@ public abstract class ExtractNatives extends DefaultRuntime {
         versionJson.getNatives().forEach(library -> {
             final File outputFile = new File(librariesDirectory, library.getPath());
             executor.submit(DownloadFileAction.class, params -> {
-                params.getIsOffline().set(getProject().getGradle().getStartParameter().isOffline());
+                params.getIsOffline().set(getIsOffline());
                 params.getShouldValidateHash().set(true);
                 params.getOutputFile().set(outputFile);
                 params.getUrl().set(library.getUrl().toString());
@@ -48,6 +91,8 @@ public abstract class ExtractNatives extends DefaultRuntime {
         });
 
         executor.await();
+
+        return librariesDirectory;
     }
 
     private void extractNatives() {
@@ -89,6 +134,9 @@ public abstract class ExtractNatives extends DefaultRuntime {
 
     @OutputDirectory
     public abstract DirectoryProperty getLibrariesDirectory();
+
+    @Input
+    public abstract Property<Boolean> getIsOffline();
 
     @Override
     public Provider<FileTree> getOutputAsTree()

--- a/common/src/main/java/net/neoforged/gradle/common/runtime/tasks/ListLibraries.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runtime/tasks/ListLibraries.java
@@ -1,6 +1,7 @@
 package net.neoforged.gradle.common.runtime.tasks;
 
 import net.neoforged.gradle.common.services.caching.CachedExecutionService;
+import net.neoforged.gradle.common.services.caching.hasher.TaskHashingAware;
 import net.neoforged.gradle.common.services.caching.jobs.ICacheableJob;
 import net.neoforged.gradle.common.util.FileCacheUtils;
 import net.neoforged.gradle.util.HashFunction;
@@ -28,7 +29,8 @@ import java.util.stream.Collectors;
 
 @SuppressWarnings("UnstableApiUsage")
 @CacheableTask
-public abstract class ListLibraries extends DefaultRuntime {
+public abstract class ListLibraries extends DefaultRuntime implements TaskHashingAware
+{
     private static final Attributes.Name FORMAT = new Attributes.Name("Bundler-Format");
     
     @SuppressWarnings("ConstantConditions")
@@ -44,6 +46,14 @@ public abstract class ListLibraries extends DefaultRuntime {
         }));
         getOutputFileName().set("libraries.txt");
         getIsOffline().convention(getProject().getGradle().getStartParameter().isOffline());
+    }
+
+    @Override
+    public Map<String, Object> getHashableProperties()
+    {
+        var properties = new HashMap<>(getInputs().getProperties());
+        properties.remove("isOffline"); //We don't care about the offline mode!
+        return properties;
     }
 
     @Input

--- a/common/src/main/java/net/neoforged/gradle/common/services/caching/CachedExecutionBuilder.java
+++ b/common/src/main/java/net/neoforged/gradle/common/services/caching/CachedExecutionBuilder.java
@@ -23,11 +23,12 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Function;
 
 public class CachedExecutionBuilder<T> {
 
-    public record LoggingOptions(boolean cacheHits, boolean debug) {}
+    public record LoggingOptions(boolean cacheHits, boolean debug, Set<String> taskPaths) {}
 
     public record Options(boolean enabled, File cache, LoggingOptions logging) {}
 
@@ -96,7 +97,7 @@ public class CachedExecutionBuilder<T> {
         this.options = options;
         this.targetTask = targetTask;
         this.stages = stages;
-        this.logger = new CacheLogger(targetTask, options.logging().debug(), options.logging().cacheHits());
+        this.logger = new CacheLogger(targetTask, options.logging().debug(), options.logging().cacheHits(), options.logging().taskPaths());
     }
 
     public <Y> CachedExecutionBuilder<Y> withStage(ICacheableJob<T, Y> job) {

--- a/common/src/main/java/net/neoforged/gradle/common/services/caching/CachedExecutionService.java
+++ b/common/src/main/java/net/neoforged/gradle/common/services/caching/CachedExecutionService.java
@@ -1,35 +1,37 @@
 package net.neoforged.gradle.common.services.caching;
 
-
+import com.google.common.collect.Sets;
 import net.neoforged.gradle.common.services.caching.jobs.ICacheableJob;
 import org.apache.commons.io.FileUtils;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.SetProperty;
 import org.gradle.api.services.BuildService;
 import org.gradle.api.services.BuildServiceParameters;
 
 import java.io.File;
 import java.io.IOException;
 
-public abstract class CachedExecutionService implements BuildService<CachedExecutionService.Parameters> {
+public abstract class CachedExecutionService implements BuildService<CachedExecutionService.Parameters>
+{
 
     public static final String NAME = "CachedExecutionService";
 
     public static final String DIRECTORY_NAME = "ng_execute";
 
-    public static final String CACHING_PROPERTY_PREFIX = "net.neoforged.gradle.caching.";
-    public static final String CACHE_DIRECTORY_PROPERTY = CACHING_PROPERTY_PREFIX + "cacheDirectory";
-    public static final String LOG_CACHE_HITS_PROPERTY = CACHING_PROPERTY_PREFIX + "logCacheHits";
-    public static final String MAX_CACHE_SIZE_PROPERTY = CACHING_PROPERTY_PREFIX + "maxCacheSize";
-    public static final String DEBUG_CACHE_PROPERTY = CACHING_PROPERTY_PREFIX + "debug";
-    public static final String IS_ENABLED_PROPERTY = CACHING_PROPERTY_PREFIX + "enabled";
+    public static final String CACHING_PROPERTY_PREFIX    = "net.neoforged.gradle.caching.";
+    public static final String CACHE_DIRECTORY_PROPERTY   = CACHING_PROPERTY_PREFIX + "cacheDirectory";
+    public static final String LOG_CACHE_HITS_PROPERTY    = CACHING_PROPERTY_PREFIX + "logCacheHits";
+    public static final String MAX_CACHE_SIZE_PROPERTY    = CACHING_PROPERTY_PREFIX + "maxCacheSize";
+    public static final String DEBUG_CACHE_PROPERTY       = CACHING_PROPERTY_PREFIX + "debug";
+    public static final String IS_ENABLED_PROPERTY        = CACHING_PROPERTY_PREFIX + "enabled";
+    public static final String TASK_PATH_FILTERS_PROPERTY = CACHING_PROPERTY_PREFIX + "taskPathFilters";
 
+    public interface Parameters extends BuildServiceParameters
+    {
 
-    public interface Parameters extends BuildServiceParameters {
-
-        DirectoryProperty getCacheDirectory();
+        Property<String> getCacheDirectory();
 
         Property<Boolean> getLogCacheHits();
 
@@ -38,45 +40,59 @@ public abstract class CachedExecutionService implements BuildService<CachedExecu
         Property<Boolean> getDebugCache();
 
         Property<Boolean> getIsEnabled();
+
+        SetProperty<String> getTaskPathFiltersForLogging();
     }
 
-    public static void register(Project project) {
+    public static void register(Project project)
+    {
         project.getGradle().getSharedServices().registerIfAbsent(
-                NAME,
-                CachedExecutionService.class,
-                spec -> {
-                    spec.getParameters().getCacheDirectory()
-                            .fileProvider(project.getProviders().gradleProperty(CACHE_DIRECTORY_PROPERTY)
-                                    .map(File::new)
-                                    .orElse(new File(new File(project.getGradle().getGradleUserHomeDir(), "caches"), DIRECTORY_NAME)));
-                    spec.getParameters().getLogCacheHits().set(project.getProviders().gradleProperty(LOG_CACHE_HITS_PROPERTY).map(Boolean::parseBoolean).orElse(false));
-                    spec.getParameters().getMaxCacheSize().set(project.getProviders().gradleProperty(MAX_CACHE_SIZE_PROPERTY).map(Integer::parseInt).orElse(100));
-                    spec.getParameters().getDebugCache().set(project.getProviders().gradleProperty(DEBUG_CACHE_PROPERTY).map(Boolean::parseBoolean).orElse(false));
-                    spec.getParameters().getIsEnabled().set(project.getProviders().gradleProperty(IS_ENABLED_PROPERTY).map(Boolean::parseBoolean).orElse(true));
-                }
+            NAME,
+            CachedExecutionService.class,
+            spec -> {
+                spec.getParameters().getCacheDirectory()
+                    .set(project.getProviders().gradleProperty(CACHE_DIRECTORY_PROPERTY)
+                        .orElse(new File(new File(project.getGradle().getGradleUserHomeDir(), "caches"), DIRECTORY_NAME).getAbsolutePath()));
+                spec.getParameters().getLogCacheHits().set(project.getProviders().gradleProperty(LOG_CACHE_HITS_PROPERTY).map(Boolean::parseBoolean).orElse(false));
+                spec.getParameters().getMaxCacheSize().set(project.getProviders().gradleProperty(MAX_CACHE_SIZE_PROPERTY).map(Integer::parseInt).orElse(100));
+                spec.getParameters().getDebugCache().set(project.getProviders().gradleProperty(DEBUG_CACHE_PROPERTY).map(Boolean::parseBoolean).orElse(false));
+                spec.getParameters().getIsEnabled().set(project.getProviders().gradleProperty(IS_ENABLED_PROPERTY).map(Boolean::parseBoolean).orElse(true));
+                spec.getParameters().getTaskPathFiltersForLogging().set(
+                    project.getProviders().gradleProperty(TASK_PATH_FILTERS_PROPERTY)
+                        .map(value -> Sets.newHashSet(value.split(";")))
+                        .orElse(Sets.newHashSet())
+                );
+            }
         );
     }
 
-    public void clean() throws IOException {
-        FileUtils.cleanDirectory(getParameters().getCacheDirectory().get().getAsFile());
+    public void clean() throws IOException
+    {
+        FileUtils.cleanDirectory(getCacheDirectory());
+    }
+
+    private File getCacheDirectory()
+    {
+        return new File(getParameters().getCacheDirectory().get());
     }
 
     public <T> CachedExecutionBuilder<T> cached(
-            Task task,
-            ICacheableJob<Void, T> initial
-    ) {
+        Task task,
+        ICacheableJob<Void, T> initial
+    )
+    {
         return new CachedExecutionBuilder<>(
-                new CachedExecutionBuilder.Options(
-                        getParameters().getIsEnabled().get(),
-                        getParameters().getCacheDirectory().get().getAsFile(),
-                        new CachedExecutionBuilder.LoggingOptions(
-                                getParameters().getLogCacheHits().get(),
-                                getParameters().getDebugCache().get()
-                        )
-                ),
-                task,
-                initial
+            new CachedExecutionBuilder.Options(
+                getParameters().getIsEnabled().get(),
+                getCacheDirectory(),
+                new CachedExecutionBuilder.LoggingOptions(
+                    getParameters().getLogCacheHits().get(),
+                    getParameters().getDebugCache().get(),
+                    getParameters().getTaskPathFiltersForLogging().get()
+                )
+            ),
+            task,
+            initial
         );
     }
-
 }

--- a/common/src/main/java/net/neoforged/gradle/common/services/caching/hasher/TaskHasher.java
+++ b/common/src/main/java/net/neoforged/gradle/common/services/caching/hasher/TaskHasher.java
@@ -10,11 +10,7 @@ import org.gradle.api.tasks.TaskInputs;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public final class TaskHasher {
     private final HashFunction hashFunction = Hashing.md5();
@@ -32,13 +28,18 @@ public final class TaskHasher {
         logger.debug("Hashing task: " + task.getPath());
         hasher.putString(task.getClass().getName());
 
-        final TaskInputs taskInputs = task.getInputs();
-        hash(taskInputs);
+        hash(task);
     }
 
-    private void hash(TaskInputs inputs) throws IOException {
+    private void hash(Task task) throws IOException {
         logger.debug("Hashing task inputs: " + task.getPath());
-        inputs.getProperties().forEach((key, value) -> {
+        var inputs = task.getInputs();
+        var properties = inputs.getProperties();
+        if (task instanceof TaskHashingAware taskHashingAware) {
+            properties = taskHashingAware.getHashableProperties();
+        }
+
+        properties.forEach((key, value) -> {
             logger.debug("Hashing task input property: " + key);
             hasher.putString(key);
             logger.debug("Hashing task input property value: " + value);

--- a/common/src/main/java/net/neoforged/gradle/common/services/caching/hasher/TaskHashingAware.java
+++ b/common/src/main/java/net/neoforged/gradle/common/services/caching/hasher/TaskHashingAware.java
@@ -1,0 +1,20 @@
+package net.neoforged.gradle.common.services.caching.hasher;
+
+import org.gradle.api.tasks.Internal;
+
+import java.util.Map;
+
+/**
+ * Defines a task which is hashing aware for our task hasher.
+ */
+public interface TaskHashingAware
+{
+
+    /**
+     * Return the map of the keys and values of the properties the hasher should consider.
+     *
+     * @return The hashable properties.
+     */
+    @Internal
+    Map<String, Object> getHashableProperties();
+}

--- a/common/src/main/java/net/neoforged/gradle/common/services/caching/logging/CacheLogger.java
+++ b/common/src/main/java/net/neoforged/gradle/common/services/caching/logging/CacheLogger.java
@@ -3,16 +3,20 @@ package net.neoforged.gradle.common.services.caching.logging;
 import net.neoforged.gradle.common.services.caching.jobs.ICacheableJob;
 import org.gradle.api.Task;
 
+import java.util.Set;
+
 public class CacheLogger {
     
     private final Task task;
     private final boolean debug;
     private final boolean cacheHits;
 
-    public CacheLogger(Task task, boolean debug, boolean cacheHits) {
+    public CacheLogger(Task task, boolean debug, boolean cacheHits, final Set<String> taskPathFilters) {
         this.task = task;
-        this.debug = debug;
-        this.cacheHits = cacheHits;
+
+        final var isEnabled = taskPathFilters.isEmpty() || taskPathFilters.contains(task.getPath());
+        this.debug = debug && isEnabled;
+        this.cacheHits = cacheHits && isEnabled;
     }
     
     public void onCacheEquals(ICacheableJob<?,?> stage) {

--- a/common/src/main/java/net/neoforged/gradle/common/tasks/FileCacheProviding.java
+++ b/common/src/main/java/net/neoforged/gradle/common/tasks/FileCacheProviding.java
@@ -1,6 +1,7 @@
 package net.neoforged.gradle.common.tasks;
 
 import com.google.gson.JsonObject;
+import net.neoforged.gradle.common.services.caching.hasher.TaskHashingAware;
 import net.neoforged.gradle.common.util.FileDownloadingUtils;
 import net.neoforged.gradle.common.util.SerializationUtils;
 import net.neoforged.gradle.dsl.common.tasks.NeoGradleBase;
@@ -18,9 +19,12 @@ import org.gradle.work.DisableCachingByDefault;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 @DisableCachingByDefault(because = "This is an abstract underlying task which provides defaults and systems for caching game artifacts.")
-public abstract class FileCacheProviding extends NeoGradleBase implements WithOutput, WithWorkspace {
+public abstract class FileCacheProviding extends NeoGradleBase implements WithOutput, WithWorkspace, TaskHashingAware
+{
 
     protected FileCacheProviding() {
         this.getFileCache().set(getSelector().map(selector -> getLayout().getProjectDirectory().dir(".gradle/caches/minecraft").dir(selector.getCacheDirectory())));
@@ -30,6 +34,14 @@ public abstract class FileCacheProviding extends NeoGradleBase implements WithOu
         
         this.getOutputFileName().set(getSelector().map(CacheFileSelector::getCacheFileName));
         this.getOutput().set(getFileCache().flatMap(cacheDir -> getOutputFileName().map(cacheDir::file)));
+    }
+
+    @Override
+    public Map<String, Object> getHashableProperties()
+    {
+        var properties = new HashMap<>(getInputs().getProperties());
+        properties.remove("isOffline"); //We don't care about the offline mode!
+        return properties;
     }
     
     @Internal

--- a/common/src/main/java/net/neoforged/gradle/common/tasks/RenderDocDownloaderTask.java
+++ b/common/src/main/java/net/neoforged/gradle/common/tasks/RenderDocDownloaderTask.java
@@ -1,5 +1,6 @@
 package net.neoforged.gradle.common.tasks;
 
+import net.neoforged.gradle.common.services.caching.hasher.TaskHashingAware;
 import net.neoforged.gradle.common.util.FileDownloadingUtils;
 import net.neoforged.gradle.common.util.VersionJson;
 import net.neoforged.gradle.dsl.common.tasks.NeoGradleBase;
@@ -12,9 +13,12 @@ import org.gradle.api.tasks.*;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 @CacheableTask
-public abstract class RenderDocDownloaderTask extends NeoGradleBase {
+public abstract class RenderDocDownloaderTask extends NeoGradleBase implements TaskHashingAware
+{
 
     public RenderDocDownloaderTask() {
         getIsOffline().set(getProject().getGradle().getStartParameter().isOffline());
@@ -26,6 +30,14 @@ public abstract class RenderDocDownloaderTask extends NeoGradleBase {
         );
 
         getOutputs().upToDateWhen(task -> false);
+    }
+
+    @Override
+    public Map<String, Object> getHashableProperties()
+    {
+        var properties = new HashMap<>(getInputs().getProperties());
+        properties.remove("isOffline"); //We don't care about the offline mode!
+        return properties;
     }
 
     @TaskAction

--- a/common/src/main/java/net/neoforged/gradle/common/util/VersionJson.java
+++ b/common/src/main/java/net/neoforged/gradle/common/util/VersionJson.java
@@ -22,8 +22,11 @@ package net.neoforged.gradle.common.util;
 
 import com.google.common.collect.ImmutableList;
 import com.google.gson.*;
+import net.neoforged.gradle.common.util.hash.Hashable;
+import net.neoforged.gradle.common.util.hash.Hasher;
 import net.neoforged.gradle.dsl.common.util.Artifact;
 import org.gradle.api.file.RegularFile;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.*;
 import java.lang.reflect.Type;
@@ -37,7 +40,8 @@ import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
-public class VersionJson implements Serializable {
+public class VersionJson implements Serializable, Hashable
+{
 
     protected static final Gson GSON = new GsonBuilder()
             .registerTypeAdapter(VersionJson.Argument.class, new VersionJson.Argument.Deserializer())
@@ -165,6 +169,12 @@ public class VersionJson implements Serializable {
 
     public static VersionJson get(RegularFile regularFile) throws IOException {
         return get(regularFile.getAsFile());
+    }
+
+    @Override
+    public void appendToHasher(final @NotNull Hasher hasher)
+    {
+        hasher.putString(this.id);
     }
 
     public static class JavaVersion implements Serializable {

--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/runtime/spec/Specification.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/runtime/spec/Specification.groovy
@@ -2,6 +2,7 @@ package net.neoforged.gradle.dsl.common.runtime.spec
 
 import com.google.common.collect.Multimap
 import groovy.transform.CompileStatic
+import net.neoforged.gradle.dsl.common.runtime.tasks.AsPartOfStep
 import net.neoforged.gradle.dsl.common.runtime.tasks.tree.TaskCustomizer
 import net.neoforged.gradle.dsl.common.util.DistributionType
 import net.neoforged.gradle.dsl.common.runtime.tasks.tree.TaskTreeAdapter
@@ -86,7 +87,7 @@ interface Specification {
     /**
      * The customizers that are allowed to change the configuration of Neoform tasks.
      */
-    @NotNull Multimap<String, TaskCustomizer<? extends Task>> getTaskCustomizers();
+    @NotNull Multimap<String, TaskCustomizer<?>> getTaskCustomizers();
 
     /**
      * Determines the specifications minecraft version.
@@ -146,6 +147,6 @@ interface Specification {
          * @param customizer   The function to apply to the task via {@link Task#configure}.
          * @return The builder instance.
          */
-         <T extends Task> B withTaskCustomizer(final String taskTypeName, Class<T> taskType, Consumer<T> customizer);
+         <T extends Task & AsPartOfStep> B withTaskCustomizer(final String taskTypeName, Class<T> taskType, Consumer<T> customizer);
     }
 }

--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/runtime/tasks/AsPartOfStep.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/runtime/tasks/AsPartOfStep.groovy
@@ -1,0 +1,34 @@
+package net.neoforged.gradle.dsl.common.runtime.tasks
+
+import net.neoforged.gdi.annotations.DSLProperty
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+
+trait AsPartOfStep {
+
+    /**
+     * The runtime directory, it is the location of the runtime working directory, inside of which the step resides.
+     *
+     * @return The runtime working directory.
+     */
+    @Internal
+    abstract DirectoryProperty getRuntimeDirectory();
+
+    /**
+     * The steps directory, it is the location of the steps working directory.
+     *
+     * @return The steps directory.
+     */
+    @Internal
+    abstract DirectoryProperty getStepsDirectory();
+
+    /**
+     * The name of the step.
+     * @return The name of the step.
+     */
+    @Input
+    @DSLProperty
+    abstract Property<String> getStepName();
+}

--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/runtime/tasks/Runtime.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/runtime/tasks/Runtime.groovy
@@ -19,7 +19,7 @@ import org.gradle.api.tasks.Nested
  * By default, it has an output.
  */
 @CompileStatic
-trait Runtime implements WithOutput, WithWorkspace, WithJavaVersion {
+trait Runtime implements WithOutput, WithWorkspace, WithJavaVersion, AsPartOfStep {
 
     /**
      * The runtime name, it is the overarching identifier of the runtime that this task is
@@ -30,34 +30,11 @@ trait Runtime implements WithOutput, WithWorkspace, WithJavaVersion {
     abstract Property<String> getRuntimeName();
 
     /**
-     * The runtime directory, it is the location of the runtime working directory.
-     * @return The mcp working directory.
-     */
-    @Internal
-    abstract DirectoryProperty getRuntimeDirectory();
-
-    /**
      * The unpacked mcp directory in the global cache.
      * @return The unpacked mcp directory.
      */
     @Internal
     abstract ConfigurableFileCollection getNeoFormArchive();
-
-    /**
-     * The steps directory, it is the location of the steps working directory.
-     *
-     * @return The steps directory.
-     */
-    @Internal
-    abstract DirectoryProperty getStepsDirectory();
-
-    /**
-     * The name of the step.
-     * @return The name of the step.
-     */
-    @Input
-    @DSLProperty
-    abstract Property<String> getStepName();
 
     /**
      * The requested distribution.

--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/runtime/tasks/tree/TaskCustomizer.java
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/runtime/tasks/tree/TaskCustomizer.java
@@ -1,6 +1,6 @@
 package net.neoforged.gradle.dsl.common.runtime.tasks.tree;
 
-import net.neoforged.gradle.dsl.common.runtime.tasks.Runtime;
+import net.neoforged.gradle.dsl.common.runtime.tasks.AsPartOfStep;
 import org.gradle.api.Task;
 
 import java.util.function.Consumer;
@@ -8,33 +8,16 @@ import java.util.function.Consumer;
 /**
  * Encapsulates a task customizer that changes the configuration of a Gradle Task encapsulating a Neoform step.
  */
-public final class TaskCustomizer<T extends Task> {
-    private final Class<T> taskClass;
-    private final Consumer<T> taskCustomizer;
-
-    public TaskCustomizer(Class<T> taskClass, Consumer<T> taskCustomizer) {
-        this.taskClass = taskClass;
-        this.taskCustomizer = taskCustomizer;
-    }
-
-    /**
-     * @return The expected task type. This will be validated to avoid unchecked casts.
-     */
-    public Class<T> getTaskClass() {
-        return taskClass;
-    }
-
-    /**
-     * @return The function that will be applied to the task using {@link Task#configure}.
-     */
-    public Consumer<T> getTaskCustomizer() {
-        return taskCustomizer;
-    }
-
-    public void apply(Runtime task) {
-        if (!taskClass.isInstance(task)) {
+public record TaskCustomizer<T extends Task & AsPartOfStep>(
+    Class<T> taskClass,
+    Consumer<T> taskCustomizer)
+{
+    public <F extends Task & AsPartOfStep> void apply(F task)
+    {
+        if (!taskClass.isInstance(task))
+        {
             throw new IllegalArgumentException("Customization for step " + task.getStepName()
-                    + " requires task type " + taskClass + " but actual task is " + task.getClass());
+                + " requires task type " + taskClass + " but actual task is " + task.getClass());
         }
         taskCustomizer.accept(taskClass.cast(task));
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,6 +37,6 @@ spock_version=2.1
 spock_groovy_version=3.0
 mockito_version=4.11.0
 jimfs_version=1.2
-trainingwheels_version=2.0.10
+trainingwheels_version=2.0.15
 
 githubCiTesting=true

--- a/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/extensions/NeoFormRuntimeExtension.java
+++ b/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/extensions/NeoFormRuntimeExtension.java
@@ -402,10 +402,12 @@ public abstract class NeoFormRuntimeExtension extends CommonRuntimeExtension<Neo
                 )
         );
 
-        final File neoFormDirectory = spec.getProject().getExtensions().getByType(ConfigurationData.class)
+        final File neoFormConfigurationDirectory = spec.getProject().getExtensions().getByType(ConfigurationData.class)
             .getLocation()
             .dir(String.format("neoForm/%s", spec.getIdentifier())).get().getAsFile();
-        final File stepsMcpDirectory = new File(neoFormDirectory, "steps");
+
+        final File neoFormBuildDirectory = spec.getProject().getLayout().getBuildDirectory().dir(String.format("neoForm/%s", spec.getIdentifier())).get().getAsFile();
+        final File stepsMcpDirectory = new File(neoFormBuildDirectory, "steps");
 
         stepsMcpDirectory.mkdirs();
 
@@ -418,11 +420,11 @@ public abstract class NeoFormRuntimeExtension extends CommonRuntimeExtension<Neo
 
         final TaskProvider<? extends ArtifactFromOutput> sourceJarTask =
             spec.getProject().getTasks().register("supplySourcesFor" + spec.getIdentifier(), ArtifactFromOutput.class, task -> {
-                task.getOutput().set(new File(neoFormDirectory, "sources.jar"));
+                task.getOutput().set(new File(neoFormBuildDirectory, "sources.jar"));
             });
         final TaskProvider<? extends ArtifactFromOutput> rawJarTask =
             spec.getProject().getTasks().register("supplyRawJarFor" + spec.getIdentifier(), ArtifactFromOutput.class, task -> {
-                task.getOutput().set(new File(neoFormDirectory, "raw.jar"));
+                task.getOutput().set(new File(neoFormBuildDirectory, "raw.jar"));
             });
 
         return new NeoFormRuntimeDefinition(
@@ -433,12 +435,12 @@ public abstract class NeoFormRuntimeExtension extends CommonRuntimeExtension<Neo
             gameArtifactTasks,
             minecraftDependenciesConfiguration,
             taskProvider -> taskProvider.configure(runtimeTask -> {
-                configureMcpRuntimeTaskWithDefaults(spec, neoFormDirectory, symbolicDataSources, runtimeTask);
+                configureMcpRuntimeTaskWithDefaults(spec, neoFormBuildDirectory, symbolicDataSources, runtimeTask);
             }),
             versionJson,
             neoFormConfig,
             createDownloadAssetsTasks(spec, versionJson),
-            createExtractNativesTasks(spec, symbolicDataSources, neoFormDirectory, versionJson)
+            createExtractNativesTasks(spec, neoFormBuildDirectory, versionJson)
         );
     }
 
@@ -467,8 +469,8 @@ public abstract class NeoFormRuntimeExtension extends CommonRuntimeExtension<Neo
 
         final File minecraftCache = artifactCacheExtension.getCacheDirectory().get().getAsFile();
 
-        final File neoFormDirectory = spec.getProject().getLayout().getBuildDirectory().dir(String.format("neoForm/%s", spec.getIdentifier())).get().getAsFile();
-        final File stepsMcpDirectory = new File(neoFormDirectory, "steps");
+        final File neoFormBuildDirectory = spec.getProject().getLayout().getBuildDirectory().dir(String.format("neoForm/%s", spec.getIdentifier())).get().getAsFile();
+        final File stepsMcpDirectory = new File(neoFormBuildDirectory, "steps");
 
         final Map<String, String> versionData = Maps.newHashMap(mappingsExtension.getVersion().get());
         versionData.put(NamingConstants.Version.MINECRAFT_VERSION, spec.getMinecraftVersion());
@@ -500,7 +502,7 @@ public abstract class NeoFormRuntimeExtension extends CommonRuntimeExtension<Neo
 
             if (spec.getPreTaskTypeAdapters().containsKey(step.getName()))
             {
-                adaptedInput = adaptPreTaskInput(definition, step, spec, taskOutputs, neoFormDirectory, symbolicDataSources, adaptedInput);
+                adaptedInput = adaptPreTaskInput(definition, step, spec, taskOutputs, neoFormBuildDirectory, symbolicDataSources, adaptedInput);
             }
 
             TaskProvider<? extends WithOutput> neoFormRuntimeTaskProvider;
@@ -551,7 +553,7 @@ public abstract class NeoFormRuntimeExtension extends CommonRuntimeExtension<Neo
             neoFormRuntimeTaskProvider.configure((WithOutput neoFormRuntimeTask) -> {
                 if (neoFormRuntimeTask instanceof Runtime runtimeTask)
                 {
-                    configureMcpRuntimeTaskWithDefaults(spec, neoFormDirectory, symbolicDataSources, taskOutputs, step, runtimeTask, finalAdaptedInput);
+                    configureMcpRuntimeTaskWithDefaults(spec, neoFormBuildDirectory, symbolicDataSources, taskOutputs, step, runtimeTask, finalAdaptedInput);
                 }
             });
 
@@ -562,13 +564,13 @@ public abstract class NeoFormRuntimeExtension extends CommonRuntimeExtension<Neo
                 {
                     final TaskProvider<? extends Runtime> taskProvider = taskTreeAdapter.adapt(definition,
                         neoFormRuntimeTaskProvider,
-                        neoFormDirectory,
+                        neoFormBuildDirectory,
                         definition.getGameArtifactProvidingTasks(),
                         definition.getMappingVersionData(),
-                        dependentTaskProvider -> dependentTaskProvider.configure(task -> configureMcpRuntimeTaskWithDefaults(spec, neoFormDirectory, symbolicDataSources, task)));
+                        dependentTaskProvider -> dependentTaskProvider.configure(task -> configureMcpRuntimeTaskWithDefaults(spec, neoFormBuildDirectory, symbolicDataSources, task)));
                     if (taskProvider != null)
                     {
-                        taskProvider.configure(task -> configureMcpRuntimeTaskWithDefaults(spec, neoFormDirectory, symbolicDataSources, task));
+                        taskProvider.configure(task -> configureMcpRuntimeTaskWithDefaults(spec, neoFormBuildDirectory, symbolicDataSources, task));
                         neoFormRuntimeTaskProvider = taskProvider;
                     }
                 }
@@ -588,7 +590,7 @@ public abstract class NeoFormRuntimeExtension extends CommonRuntimeExtension<Neo
             definition,
             "recompile",
             spec,
-            neoFormDirectory,
+            neoFormBuildDirectory,
             symbolicDataSources,
             Optional.of(lastTask),
             Optional.of(lastTask)
@@ -599,7 +601,7 @@ public abstract class NeoFormRuntimeExtension extends CommonRuntimeExtension<Neo
 
         final TaskProvider<? extends Runtime> recompileTask =
             createRecompileTask(definition, recompileInput, recompileDependencies, task -> {
-                task.configure(neoFormRuntimeTask -> configureMcpRuntimeTaskWithDefaults(spec, neoFormDirectory, symbolicDataSources, neoFormRuntimeTask));
+                task.configure(neoFormRuntimeTask -> configureMcpRuntimeTaskWithDefaults(spec, neoFormBuildDirectory, symbolicDataSources, neoFormRuntimeTask));
             });
 
         taskOutputs.put(recompileTask.getName(), recompileTask);

--- a/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/tasks/DownloadFile.java
+++ b/neoform/src/main/java/net/neoforged/gradle/neoform/runtime/tasks/DownloadFile.java
@@ -1,32 +1,50 @@
 package net.neoforged.gradle.neoform.runtime.tasks;
 
 import net.neoforged.gradle.common.runtime.tasks.DefaultRuntime;
+import net.neoforged.gradle.common.services.caching.hasher.TaskHashingAware;
 import net.neoforged.gradle.common.util.FileDownloadingUtils;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.*;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 @CacheableTask
-public abstract class DownloadFile extends DefaultRuntime {
+public abstract class DownloadFile extends DefaultRuntime implements TaskHashingAware
+{
 
-    public DownloadFile() {
+    public DownloadFile()
+    {
         getDownloadInfo().finalizeValueOnRead();
         getIsOffline().convention(getProject().getGradle().getStartParameter().isOffline());
     }
 
+    @Override
+    public Map<String, Object> getHashableProperties()
+    {
+        var properties = new HashMap<>(getInputs().getProperties());
+        properties.remove("isOffline"); //We don't care about the offline mode!
+        return properties;
+    }
+
     @TaskAction
-    public void run() throws Exception {
-        if (getDownloadInfo().isPresent()) {
+    public void run() throws Exception
+    {
+        if (getDownloadInfo().isPresent())
+        {
             final FileDownloadingUtils.DownloadInfo info = getDownloadInfo().get();
             doDownloadFrom(info);
-        } else {
+        }
+        else
+        {
             throw new IllegalStateException("No download info provided");
         }
     }
 
-    protected void doDownloadFrom(FileDownloadingUtils.DownloadInfo info) throws IOException {
+    protected void doDownloadFrom(FileDownloadingUtils.DownloadInfo info) throws IOException
+    {
         final File outputFile = ensureFileWorkspaceReady(getOutput());
 
         FileDownloadingUtils.downloadTo(getIsOffline().get(), info, outputFile);
@@ -37,9 +55,8 @@ public abstract class DownloadFile extends DefaultRuntime {
     @Nested
     @Optional
     public abstract Property<FileDownloadingUtils.DownloadInfo> getDownloadInfo();
-    
+
     @Input
     @Optional
     public abstract Property<Boolean> getIsOffline();
-
 }

--- a/test-utils/src/main/groovy/net/neoforged/gradle/utils/test/extensions/RuntimeBuilderExtensions.groovy
+++ b/test-utils/src/main/groovy/net/neoforged/gradle/utils/test/extensions/RuntimeBuilderExtensions.groovy
@@ -21,6 +21,7 @@ class RuntimeBuilderExtensions {
      */
     static File withGlobalCacheDirectory(final Runtime.Builder self, final File testProjectDir) {
         final File cacheDir = new File(testProjectDir, ".ng-cache")
+        cacheDir.mkdirs()
         self.property(CachedExecutionService.CACHE_DIRECTORY_PROPERTY, cacheDir.getPropertiesPath())
 
         return cacheDir

--- a/userdev/src/functionalTest/groovy/net/neoforged/gradle/userdev/OfflineModeTests.groovy
+++ b/userdev/src/functionalTest/groovy/net/neoforged/gradle/userdev/OfflineModeTests.groovy
@@ -1,0 +1,42 @@
+package net.neoforged.gradle.userdev
+
+import net.neoforged.gradle.common.services.caching.CachedExecutionService
+import net.neoforged.trainingwheels.gradle.functional.BuilderBasedTestSpecification
+import org.gradle.internal.impldep.org.bouncycastle.util.BigIntegers
+import org.gradle.testkit.runner.TaskOutcome
+import net.neoforged.gradle.userdev.constants.TestConstants
+
+class OfflineModeTests extends BuilderBasedTestSpecification {
+
+    @Override
+    protected void configurePluginUnderTest() {
+        pluginUnderTest = "net.neoforged.gradle.userdev";
+        injectIntoAllProject = true;
+    }
+
+    def "running_a_second_time_should_be_possible_when_offline"() {
+        given:
+        def project = create("running_second_when_offline", {
+            it.withRun()
+            it.retainBuildDirectoryBetweenRuns()
+        })
+
+        when:
+        def run = project.run {
+            it.run()
+        }
+
+        then:
+        run.checkModLoading()
+
+        when:
+        project.resetSelfTestFile()
+        def runOffline = project.run {
+            it.offline()
+            it.run()
+        }
+
+        then:
+        runOffline.checkModLoading()
+    }
+}

--- a/userdev/src/functionalTest/groovy/net/neoforged/gradle/userdev/extensions/TestExtensions.groovy
+++ b/userdev/src/functionalTest/groovy/net/neoforged/gradle/userdev/extensions/TestExtensions.groovy
@@ -4,7 +4,9 @@ import net.neoforged.trainingwheels.gradle.functional.builder.Runtime.Builder
 import net.neoforged.trainingwheels.gradle.functional.builder.Runtime.RunBuilder
 import net.neoforged.trainingwheels.gradle.functional.builder.Runtime.RunResult
 import org.gradle.testkit.runner.TaskOutcome
-import net.neoforged.gradle.userdev.constants.TestConstants;
+import net.neoforged.gradle.userdev.constants.TestConstants
+
+import java.util.function.Consumer;
 
 class TestExtensions {
 
@@ -73,7 +75,7 @@ class TestExtensions {
             
             runs {
                 server { 
-                    environmentVariables.put('NEOFORGE_DEDICATED_SERVER_SELFTEST', "${(new Date()).format('ddMMyy_HHmm')}.json")
+                    environmentVariables.put('NEOFORGE_DEDICATED_SERVER_SELFTEST', "server_self_test.json")
                     arguments.add('--nogui')
                 }
             }
@@ -154,5 +156,36 @@ class TestExtensions {
     static boolean checkModLoading(RunResult self,
                                    String projectPrefix = "") {
         return self.task(projectPrefix + ':runServer').outcome == TaskOutcome.SUCCESS && self.output.contains("NeoGradle Test Mod has been loaded successfully!")
+    }
+
+    static void updatePropertiesFile(net.neoforged.trainingwheels.gradle.functional.builder.Runtime self,
+            Consumer<Properties> updater
+    ) {
+        final File propertiesFile = self.file("gradle.properties")
+        if (!propertiesFile.exists()) {
+            propertiesFile.parentFile.mkdirs()
+            propertiesFile.createNewFile()
+        }
+
+        final Properties result = new Properties()
+        try(InputStream stream = new FileInputStream(propertiesFile)) {
+            result.load(stream)
+        }
+
+        updater.accept(result);
+
+        if (propertiesFile.exists()) {
+            propertiesFile.delete()
+            propertiesFile.createNewFile()
+        }
+        try(OutputStream stream = new FileOutputStream(propertiesFile)) {
+            result.store(stream, "Gradle properties updated by test run")
+        }
+    }
+
+    static void resetSelfTestFile(net.neoforged.trainingwheels.gradle.functional.builder.Runtime self) {
+        var selfTestFile = self.file("runs/server/server_self_test.json")
+        if (selfTestFile.exists())
+            selfTestFile.delete()
     }
 }


### PR DESCRIPTION
Changes:
- Provide support for tasks which have properties which do not need to be cached (like offline mode flags)
- Exclude the offline mode flag from the DownloadAssets, ExtractNatives, and ListLibraries, FileCacheProviding and RenderDocDownloaderTask, DownloadFile
- Add support for filtering the tasks which the cache logger emits log information for
- Support hashing of the VersionJson object for several tasks
- Update signature of TaskCustomizer to support tasks which are not directly part of the runtime, for example for handling extract natives.
- Add tests to cover offline mode.