### PR TITLE
Add JarJar convention to not create default main

### DIFF
--- a/README.md
+++ b/README.md
@@ -852,6 +852,19 @@ neogradle.subsystems.conventions.runs.renderdoc.conventionForRun=true
 ```
 This will enable the render doc tool for all client runs, unless explicitly disabled.
 
+### JarJar
+To disable the jarJar conventions, you can set the following property in your gradle.properties:
+```properties
+neogradle.subsystems.conventions.jarjar.enabled=false
+```
+
+#### Default Main JarJar Feature
+By default, NeoGradle registers a `jarJar` task and configuration for the main source set.
+If you want to disable this (for example, to define your own jarJar features via `jarJar.forFeature(...)`), you can set the following property in your gradle.properties:
+```properties
+neogradle.subsystems.conventions.jarjar.create-main-jarjar=false
+```
+
 
 ## Tool overrides
 To configure tools used by different subsystems of NG, the subsystems dsl and properties can be used to configure the following tools:

--- a/common/src/main/java/net/neoforged/gradle/common/extensions/subsystems/ConventionsExtension.java
+++ b/common/src/main/java/net/neoforged/gradle/common/extensions/subsystems/ConventionsExtension.java
@@ -5,6 +5,7 @@ import net.neoforged.gradle.common.extensions.base.WithEnabledProperty;
 import net.neoforged.gradle.dsl.common.extensions.subsystems.Conventions;
 import net.neoforged.gradle.dsl.common.extensions.subsystems.conventions.Configurations;
 import net.neoforged.gradle.dsl.common.extensions.subsystems.conventions.IDE;
+import net.neoforged.gradle.dsl.common.extensions.subsystems.conventions.JarJar;
 import net.neoforged.gradle.dsl.common.extensions.subsystems.conventions.Runs;
 import net.neoforged.gradle.dsl.common.extensions.subsystems.conventions.SourceSets;
 import net.neoforged.gradle.dsl.common.extensions.subsystems.conventions.ide.IDEA;
@@ -20,6 +21,7 @@ public abstract class ConventionsExtension extends WithEnabledProperty implement
     private final SourceSets sourceSets;
     private final IDE ide;
     private final Runs runs;
+    private final JarJar jarJar;
 
     @Inject
     public ConventionsExtension(Project project) {
@@ -29,6 +31,7 @@ public abstract class ConventionsExtension extends WithEnabledProperty implement
         this.sourceSets = project.getObjects().newInstance(SourceSetsExtension.class, this);
         this.ide = project.getObjects().newInstance(IDEExtension.class, this);
         this.runs = project.getObjects().newInstance(RunsExtension.class, this);
+        this.jarJar = project.getObjects().newInstance(JarJarExtension.class, this);
     }
 
     @Override
@@ -49,6 +52,11 @@ public abstract class ConventionsExtension extends WithEnabledProperty implement
     @Override
     public Runs getRuns() {
         return runs;
+    }
+
+    @Override
+    public JarJar getJarJar() {
+        return jarJar;
     }
 
     public static abstract class ConfigurationsExtension extends WithEnabledProperty implements BaseDSLElement<Configurations>, Configurations {
@@ -137,6 +145,16 @@ public abstract class ConventionsExtension extends WithEnabledProperty implement
             super(parent, "renderdoc");
 
             getConventionForRun().convention(getBooleanProperty("conventionForRun", false, false));
+        }
+    }
+
+    public static abstract class JarJarExtension extends WithEnabledProperty implements BaseDSLElement<JarJar>, JarJar {
+
+        @Inject
+        public JarJarExtension(WithEnabledProperty parent) {
+            super(parent, "jarjar");
+
+            getShouldDefaultMainFeatureBeCreated().convention(getBooleanProperty("create-main-jarjar", true, false));
         }
     }
 

--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/extensions/subsystems/Conventions.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/extensions/subsystems/Conventions.groovy
@@ -5,6 +5,7 @@ import net.neoforged.gdi.BaseDSLElement
 import net.neoforged.gdi.annotations.DSLProperty
 import net.neoforged.gradle.dsl.common.extensions.subsystems.conventions.Configurations
 import net.neoforged.gradle.dsl.common.extensions.subsystems.conventions.IDE
+import net.neoforged.gradle.dsl.common.extensions.subsystems.conventions.JarJar
 import net.neoforged.gradle.dsl.common.extensions.subsystems.conventions.Runs
 import net.neoforged.gradle.dsl.common.extensions.subsystems.conventions.SourceSets
 import org.gradle.api.provider.Property
@@ -50,4 +51,11 @@ interface Conventions extends BaseDSLElement<Conventions> {
     @Nested
     @DSLProperty
     Runs getRuns()
+
+    /**
+     * The jarJar conventions used by NeoGradle.
+     */
+    @Nested
+    @DSLProperty
+    JarJar getJarJar()
 }

--- a/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/extensions/subsystems/conventions/JarJar.groovy
+++ b/dsl/common/src/main/groovy/net/neoforged/gradle/dsl/common/extensions/subsystems/conventions/JarJar.groovy
@@ -1,0 +1,26 @@
+package net.neoforged.gradle.dsl.common.extensions.subsystems.conventions
+
+import net.neoforged.gdi.BaseDSLElement
+import net.neoforged.gdi.annotations.DSLProperty
+import org.gradle.api.provider.Property
+
+/**
+ * Allows configuration of the individual conventions related to jarJar used by NeoGradle.
+ */
+interface JarJar extends BaseDSLElement<JarJar> {
+
+    /**
+     * Global flag to enable or disable the jarJar conventions system. If disabled, no conventions jarJar features will be created or used.
+     * Note: this can not be configured via the buildscript and needs to be set in the gradle.properties file.
+     */
+    @DSLProperty
+    Property<Boolean> getIsEnabled()
+
+    /**
+     * Whether or not the default jarJar feature for the main source set should be created.
+     * When set to {@code false}, NeoGradle will not register the {@code jarJar} task or its configuration,
+     * leaving consumers free to define their own jarJar features via {@link net.neoforged.gradle.dsl.common.extensions.JarJar#forFeature(String)}.
+     */
+    @DSLProperty
+    Property<Boolean> getShouldDefaultMainFeatureBeCreated()
+}

--- a/userdev/src/functionalTest/groovy/net/neoforged/gradle/userdev/convention/JarJarConventionTests.groovy
+++ b/userdev/src/functionalTest/groovy/net/neoforged/gradle/userdev/convention/JarJarConventionTests.groovy
@@ -1,0 +1,169 @@
+package net.neoforged.gradle.userdev.convention
+
+
+import net.neoforged.gradle.userdev.constants.TestConstants
+import net.neoforged.trainingwheels.gradle.functional.BuilderBasedTestSpecification
+
+/**
+ * Tests the jarJar conventions.
+ */
+class JarJarConventionTests extends BuilderBasedTestSpecification {
+    @Override
+    protected void configurePluginUnderTest() {
+        pluginUnderTest = "net.neoforged.gradle.userdev";
+        injectIntoAllProject = true;
+    }
+
+    def "by default the main jarJar task and configuration are created"() {
+        given:
+        def project = create("jarjar_default_creates_main_feature", {
+            it.build("""
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(${TestConstants.Latest.JavaVersion})
+                }
+            }
+
+            repositories {
+                mavenCentral()
+            }
+
+            dependencies {
+                implementation 'net.neoforged:neoforge:+'
+            }
+
+            afterEvaluate {
+                logger.lifecycle("JarJar task present: \${project.tasks.findByName('jarJar') != null}")
+                logger.lifecycle("JarJar configuration present: \${project.configurations.findByName('jarJar') != null}")
+            }
+            """)
+            it.withToolchains()
+            it.withGlobalCacheDirectory(tempDir)
+        })
+
+        when:
+        def run = project.run {
+            it.tasks(':help')
+        }
+
+        then:
+        run.output.contains("JarJar task present: true")
+        run.output.contains("JarJar configuration present: true")
+    }
+
+    def "disabling create-main-jarjar prevents the main jarJar task and configuration from being created"() {
+        given:
+        def project = create("jarjar_disable_main_feature", {
+            it.property('neogradle.subsystems.conventions.jarjar.create-main-jarjar', 'false')
+            it.build("""
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(${TestConstants.Latest.JavaVersion})
+                }
+            }
+
+            repositories {
+                mavenCentral()
+            }
+
+            dependencies {
+                implementation 'net.neoforged:neoforge:+'
+            }
+
+            afterEvaluate {
+                logger.lifecycle("JarJar task present: \${project.tasks.findByName('jarJar') != null}")
+                logger.lifecycle("JarJar configuration present: \${project.configurations.findByName('jarJar') != null}")
+            }
+            """)
+            it.withToolchains()
+            it.withGlobalCacheDirectory(tempDir)
+        })
+
+        when:
+        def run = project.run {
+            it.tasks(':help')
+        }
+
+        then:
+        run.output.contains("JarJar task present: false")
+        run.output.contains("JarJar configuration present: false")
+    }
+
+    def "disabling jarjar conventions globally prevents the main jarJar task and configuration from being created"() {
+        given:
+        def project = create("jarjar_disable_conventions_globally", {
+            it.property('neogradle.subsystems.conventions.jarjar.enabled', 'false')
+            it.build("""
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(${TestConstants.Latest.JavaVersion})
+                }
+            }
+
+            repositories {
+                mavenCentral()
+            }
+
+            dependencies {
+                implementation 'net.neoforged:neoforge:+'
+            }
+
+            afterEvaluate {
+                logger.lifecycle("JarJar task present: \${project.tasks.findByName('jarJar') != null}")
+                logger.lifecycle("JarJar configuration present: \${project.configurations.findByName('jarJar') != null}")
+            }
+            """)
+            it.withToolchains()
+            it.withGlobalCacheDirectory(tempDir)
+        })
+
+        when:
+        def run = project.run {
+            it.tasks(':help')
+        }
+
+        then:
+        run.output.contains("JarJar task present: false")
+        run.output.contains("JarJar configuration present: false")
+    }
+
+    def "with create-main-jarjar disabled the jarJar extension is still registered for custom features"() {
+        given:
+        def project = create("jarjar_extension_present_when_default_disabled", {
+            it.property('neogradle.subsystems.conventions.jarjar.create-main-jarjar', 'false')
+            it.build("""
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(${TestConstants.Latest.JavaVersion})
+                }
+            }
+
+            repositories {
+                mavenCentral()
+            }
+
+            dependencies {
+                implementation 'net.neoforged:neoforge:+'
+            }
+
+            afterEvaluate {
+                logger.lifecycle("JarJar extension present: \${project.extensions.findByName('jarJar') != null}")
+                logger.lifecycle("Default jarJar task present: \${project.tasks.findByName('jarJar') != null}")
+                logger.lifecycle("Default jarJar configuration present: \${project.configurations.findByName('jarJar') != null}")
+            }
+            """)
+            it.withToolchains()
+            it.withGlobalCacheDirectory(tempDir)
+        })
+
+        when:
+        def run = project.run {
+            it.tasks(':help')
+        }
+
+        then:
+        run.output.contains("JarJar extension present: true")
+        run.output.contains("Default jarJar task present: false")
+        run.output.contains("Default jarJar configuration present: false")
+    }
+}

--- a/userdev/src/main/java/net/neoforged/gradle/userdev/UserDevProjectPlugin.java
+++ b/userdev/src/main/java/net/neoforged/gradle/userdev/UserDevProjectPlugin.java
@@ -3,6 +3,7 @@ package net.neoforged.gradle.userdev;
 import net.neoforged.gradle.common.extensions.DefaultJarJarFeature;
 import net.neoforged.gradle.common.extensions.JarJarExtension;
 import net.neoforged.gradle.dsl.common.extensions.JarJar;
+import net.neoforged.gradle.dsl.common.extensions.subsystems.Subsystems;
 import net.neoforged.gradle.neoform.NeoFormPlugin;
 import net.neoforged.gradle.userdev.dependency.UserDevDependencyManager;
 import net.neoforged.gradle.userdev.runtime.extension.UserDevRuntimeExtension;
@@ -30,6 +31,10 @@ public class UserDevProjectPlugin implements Plugin<Project> {
     }
 
     protected void configureJarJarTask(Project project, JarJar jarJarExtension) {
-        ((DefaultJarJarFeature) jarJarExtension).createTaskAndConfiguration();
+        final boolean createMainFeature = project.getExtensions().getByType(Subsystems.class)
+                .getConventions().getJarJar().getShouldDefaultMainFeatureBeCreated().get();
+        if (createMainFeature) {
+            ((DefaultJarJarFeature) jarJarExtension).createTaskAndConfiguration();
+        }
     }
 }


### PR DESCRIPTION
Added a new convention subsystem: `jarjar`:

```properties
neogradle.subsystems.conventions.jarjar.enabled=false
neogradle.subsystems.conventions.jarjar.create-main-jarjar=false
```

Prevents userdev from creating the feature for the main sourceset when set to false.

### Checklist

- [x] Added conventions
- [x] Wired convention to userdev
- [x] Added tests
- [x] Updated docs

### Related issues

Fixes #312 