### PR TITLE
Use `Project.ext` as a fallback for property lookups

### DIFF
--- a/common/src/main/java/net/neoforged/gradle/common/extensions/base/WithPropertyLookup.java
+++ b/common/src/main/java/net/neoforged/gradle/common/extensions/base/WithPropertyLookup.java
@@ -3,11 +3,13 @@ package net.neoforged.gradle.common.extensions.base;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.file.Directory;
+import org.gradle.api.plugins.ExtraPropertiesExtension;
 import org.gradle.api.provider.Provider;
 
 import java.io.File;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import static net.neoforged.gradle.dsl.common.util.Constants.SUBSYSTEM_PROPERTY_PREFIX;
 
@@ -19,7 +21,7 @@ public abstract class WithPropertyLookup {
     }
 
     protected Provider<String> getStringProperty(String propertyName, String defaultValue) {
-        final Provider<String> property = this.project.getProviders().gradleProperty(SUBSYSTEM_PROPERTY_PREFIX + propertyName);
+        final Provider<String> property = this.getProperty(SUBSYSTEM_PROPERTY_PREFIX + propertyName);
         if (defaultValue == null)
             return property;
 
@@ -27,14 +29,14 @@ public abstract class WithPropertyLookup {
     }
 
     protected Provider<Directory> getDirectoryProperty(String propertyName, Provider<Directory> defaultValue) {
-        return this.project.getProviders().gradleProperty(SUBSYSTEM_PROPERTY_PREFIX + propertyName)
+        return this.getProperty(SUBSYSTEM_PROPERTY_PREFIX + propertyName)
                 .flatMap(path -> project.getLayout().dir(project.provider(() -> new File(path))))
                 .orElse(defaultValue);
     }
 
     protected Provider<Boolean> getBooleanProperty(String propertyName, boolean defaultValue, boolean disabledValue) {
         String fullPropertyName = SUBSYSTEM_PROPERTY_PREFIX + propertyName;
-        return this.project.getProviders().gradleProperty(fullPropertyName)
+        return this.getProperty(fullPropertyName)
             .map(value -> {
                 try {
                     return Boolean.valueOf(value);
@@ -46,7 +48,7 @@ public abstract class WithPropertyLookup {
 
     protected Provider<Boolean> getBooleanProperty(String propertyName) {
         String fullPropertyName = SUBSYSTEM_PROPERTY_PREFIX + propertyName;
-        return this.project.getProviders().gradleProperty(fullPropertyName)
+        return this.getProperty(fullPropertyName)
             .map(value -> {
                 try {
                     return Boolean.valueOf(value);
@@ -57,9 +59,27 @@ public abstract class WithPropertyLookup {
     }
 
     protected Provider<List<String>> getSpaceSeparatedListProperty(String propertyName, List<String> defaultValue) {
-        return this.project.getProviders().gradleProperty(SUBSYSTEM_PROPERTY_PREFIX + propertyName)
+        return this.getProperty(SUBSYSTEM_PROPERTY_PREFIX + propertyName)
                 .map(s -> Arrays.asList(s.split("\\s+")))
                 .orElse(defaultValue);
+    }
+
+    private Provider<String> getProperty(String propertyName) {
+        // Take a snapshot of the extra property at configuration as a fallback.
+        // Extra properties are intended to be provided from other Gradle plugins that are
+        // applied before this plugin to set default values programmatically.
+        ExtraPropertiesExtension ext = this.project.getExtensions().getExtraProperties();
+        String extValue;
+        if (ext.has(propertyName)) {
+            extValue = Objects.toString(ext.get(propertyName));
+        } else {
+            extValue = null;
+        }
+
+        Provider<String> gradleProperty = this.project.getProviders().gradleProperty(propertyName);
+        Provider<String> extProperty = this.project.getProviders().provider(() -> extValue);
+
+        return gradleProperty.orElse(extProperty);
     }
 
     public Project getProject() {


### PR DESCRIPTION
## What

I have made `WithPropertyLookup` source from a configuration-time snapshot value
of `Project.ext` as a fallback for property lookups, when `providers.gradleProperty()` has no value.

## Why

This change allows for programmatic configuration of NeoGradle conventions.

Such uses include: 

- Plugins that apply before NeoGradle may set conventions required for NeoGradle to correctly behave in conjunction with it.
- `build-logic` conventions plugins may set the same set of conventions across all applied projects.
 