### PR TITLE
Enforce that the recompile runs with a requested version.

### DIFF
--- a/common/src/main/java/net/neoforged/gradle/common/runtime/tasks/RecompileSourceJar.java
+++ b/common/src/main/java/net/neoforged/gradle/common/runtime/tasks/RecompileSourceJar.java
@@ -96,6 +96,10 @@ public abstract class RecompileSourceJar extends JavaCompile implements Runtime 
         );
 
         getOptions().setSourcepath(sourcePaths);
+
+        getOptions().getRelease().set(
+            getJavaVersion().map(JavaLanguageVersion::asInt)
+        );
     }
 
     @Override


### PR DESCRIPTION
This fixes a cross java version compile issue where the recompiler would use what ever version is available as toolchain, regardless of what is needed, and what is set, even though the requested release is lower then the compile target.